### PR TITLE
Update leaderboard entry createdAt when score is updated

### DIFF
--- a/src/entities/leaderboard-entry.ts
+++ b/src/entities/leaderboard-entry.ts
@@ -41,6 +41,7 @@ export default class LeaderboardEntry {
         identifier: this.playerAlias.identifier
       },
       hidden: this.hidden,
+      createdAt: this.createdAt,
       updatedAt: this.updatedAt
     }
   }

--- a/src/services/api/leaderboard-api.service.ts
+++ b/src/services/api/leaderboard-api.service.ts
@@ -64,6 +64,7 @@ export default class LeaderboardAPIService extends APIService<LeaderboardService
 
         if ((leaderboard.sortMode === LeaderboardSortMode.ASC && score < entry.score) || (leaderboard.sortMode === LeaderboardSortMode.DESC && score > entry.score)) {
           entry.score = score
+          entry.createdAt = new Date()
           await em.flush()
 
           updated = true


### PR DESCRIPTION
This makes it easier to see on the frontend when the actual entry was created/updated, instead of the updatedAt which can change e.g. when the entry is hidden.