### PR TITLE
Fix secret loading for socket message verification

### DIFF
--- a/src/socket/messages/socketLogger.ts
+++ b/src/socket/messages/socketLogger.ts
@@ -18,7 +18,11 @@ export function logRequest(conn: SocketConnection, message: string) {
 
   let req = ''
   try {
-    req = JSON.parse(message).req ?? 'unknown'
+    const jsonStr =
+      conn.verifyRequests && message.includes('\n')
+        ? message.slice(message.indexOf('\n') + 1)
+        : message
+    req = JSON.parse(jsonStr).req ?? 'unknown'
   } catch {
     req = 'unknown'
   } finally {

--- a/src/socket/router/socketRouter.ts
+++ b/src/socket/router/socketRouter.ts
@@ -256,7 +256,7 @@ export default class SocketRouter {
       return false
     }
 
-    const game = await em.repo(Game).findOneOrFail(conn.gameId)
+    const game = await em.repo(Game).findOneOrFail(conn.gameId, { populate: ['apiSecret'] })
 
     return verifySignature({
       signature,


### PR DESCRIPTION
**Socket request signing support**
- `socketLogger.ts`: Updated `logRequest` to strip a leading signature line (separated by newline) before parsing the JSON body when `conn.verifyRequests` is enabled, so the logger correctly extracts the request name from signed messages.
- `socketRouter.ts`: Added eager population of `game.apiSecret` during socket connection validation, ensuring the API secret is available for verifying request signatures at the routing level.