### PR TITLE
Release 0.128.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "game-services",
-  "version": "0.128.0",
+  "version": "0.128.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "game-services",
-      "version": "0.128.0",
+      "version": "0.128.1",
       "license": "MIT",
       "dependencies": {
         "@clickhouse/client": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-services",
-  "version": "0.128.0",
+  "version": "0.128.1",
   "description": "",
   "license": "MIT",
   "author": "Talo Platform Ltd",

--- a/src/socket/messages/socketLogger.ts
+++ b/src/socket/messages/socketLogger.ts
@@ -18,7 +18,11 @@ export function logRequest(conn: SocketConnection, message: string) {
 
   let req = ''
   try {
-    req = JSON.parse(message).req ?? 'unknown'
+    const jsonStr =
+      conn.verifyRequests && message.includes('\n')
+        ? message.slice(message.indexOf('\n') + 1)
+        : message
+    req = JSON.parse(jsonStr).req ?? 'unknown'
   } catch {
     req = 'unknown'
   } finally {

--- a/src/socket/router/socketRouter.ts
+++ b/src/socket/router/socketRouter.ts
@@ -256,7 +256,7 @@ export default class SocketRouter {
       return false
     }
 
-    const game = await em.repo(Game).findOneOrFail(conn.gameId)
+    const game = await em.repo(Game).findOneOrFail(conn.gameId, { populate: ['apiSecret'] })
 
     return verifySignature({
       signature,


### PR DESCRIPTION
**Socket request logging fix**
- When `verifyRequests` is enabled, incoming WebSocket messages include a signature prepended as a line. The logger now strips that signature line before JSON-parsing the message, fixing `JSON.parse` failures that caused all such requests to be logged as `unknown`.

**Signature verification fix**
- The Game lookup in socket-router now eagerly populates the `apiSecret` relation so that signature verification always has access to the secret, preventing failures from lazy-loading outside an active database context.

**Version bump**
- Patch version bumped from 0.128.0 to 0.128.1 for the two fixes above.