### PR TITLE
Fix profanity being detected in numeric/punctuation-only text

### DIFF
--- a/src/lib/filters/profanity.ts
+++ b/src/lib/filters/profanity.ts
@@ -16,5 +16,10 @@ function getMatcher() {
 }
 
 export function hasProfanity(text: string) {
+  // numeric/punctuation values can leetspeak-decode into profane words (e.g. "460240" -> "goza").
+  // skip the check unless the value contains any letter.
+  if (!/\p{L}/u.test(text)) {
+    return false
+  }
   return getMatcher().hasMatch(text)
 }

--- a/tests/routes/api/player/patch.test.ts
+++ b/tests/routes/api/player/patch.test.ts
@@ -417,6 +417,36 @@ describe('Player API - update', () => {
     ])
   })
 
+  it('should accept numeric coordinate values when blockPropsProfanity is enabled', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.WRITE_PLAYERS])
+    apiKey.game.blockPropsProfanity = true
+    await em.flush()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    await em.persist(player).flush()
+
+    const res = await request(app)
+      .patch(`/v1/players/${player.id}`)
+      .send({
+        props: [
+          { key: 'path[]', value: '0,0' },
+          { key: 'path[]', value: '142,460' },
+          { key: 'path[]', value: '240,555' },
+        ],
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.rejectedProps).toEqual([])
+    expect(res.body.player.props).toEqual(
+      expect.arrayContaining([
+        { key: 'path[]', value: '0,0' },
+        { key: 'path[]', value: '142,460' },
+        { key: 'path[]', value: '240,555' },
+      ]),
+    )
+  })
+
   it('should allow profane props when blockPropsProfanity is disabled', async () => {
     const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.WRITE_PLAYERS])
 


### PR DESCRIPTION
**Profanity filter false positive fix**
- Numeric-only strings (e.g. coordinates like `"142,460"`) were being flagged as profane because the matcher decoded them as leetspeak, producing words like `"goza"`.
- The profanity check now skips strings that contain no Unicode letters, since leetspeak decoding is only relevant when letters are present.
- This prevents game data such as coordinate arrays from being incorrectly rejected when `blockPropsProfanity` is enabled.