### PR TITLE
Add admin stats list route

### DIFF
--- a/src/routes/admin/game-stat/index.ts
+++ b/src/routes/admin/game-stat/index.ts
@@ -1,12 +1,14 @@
 import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createStatAdminRoute } from './create.js'
+import { listStatsAdminRoute } from './list.js'
 
 export function gameStatAdminRouter(router: Router) {
   adminRouter(
     '/admin/v1/game-stats',
     ({ route }) => {
       route(createStatAdminRoute)
+      route(listStatsAdminRoute)
     },
     { router, docsKey: 'adminGameStats' },
   )

--- a/src/routes/admin/game-stat/index.ts
+++ b/src/routes/admin/game-stat/index.ts
@@ -10,6 +10,6 @@ export function gameStatAdminRouter(router: Router) {
       route(createStatAdminRoute)
       route(listStatsAdminRoute)
     },
-    { router, docsKey: 'adminGameStats' },
+    { router, docsKey: 'GameStatAdminAPI' },
   )
 }

--- a/src/routes/admin/game-stat/list.ts
+++ b/src/routes/admin/game-stat/list.ts
@@ -1,0 +1,29 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { listStatsHandler } from '../../protected/game-stat/list.js'
+
+export const listStatsAdminRoute = adminRoute({
+  method: 'get',
+  schema: (z) => ({
+    query: z.object({
+      withMetrics: z.string().optional(),
+      metricsStartDate: z.string().optional(),
+      metricsEndDate: z.string().optional(),
+    }),
+  }),
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_STATS])),
+  handler: (ctx) => {
+    const { withMetrics, metricsStartDate, metricsEndDate } = ctx.state.validated.query
+
+    return listStatsHandler({
+      em: ctx.em,
+      game: ctx.state.game,
+      includeDevData: ctx.state.includeDevData,
+      clickhouse: ctx.clickhouse,
+      withMetrics,
+      metricsStartDate,
+      metricsEndDate,
+    })
+  },
+})

--- a/src/routes/protected/game-stat/list.ts
+++ b/src/routes/protected/game-stat/list.ts
@@ -1,7 +1,72 @@
+import type { ClickHouseClient } from '@clickhouse/client'
+import type { EntityManager } from '@mikro-orm/mysql'
+import type Game from '../../../entities/game.js'
 import GameStat from '../../../entities/game-stat.js'
 import { withResponseCache } from '../../../lib/perf/responseCache.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
+
+export async function listStatsHandler({
+  em,
+  game,
+  includeDevData,
+  clickhouse,
+  withMetrics,
+  metricsStartDate,
+  metricsEndDate,
+}: {
+  em: EntityManager
+  game: Game
+  includeDevData: boolean
+  clickhouse: ClickHouseClient
+  withMetrics?: string
+  metricsStartDate?: string
+  metricsEndDate?: string
+}) {
+  return withResponseCache(
+    {
+      key: `${GameStat.getIndexCacheKey(game)}-${withMetrics}-${metricsStartDate}-${metricsEndDate}-${includeDevData ? 'dev' : 'no-dev'}`,
+    },
+    async () => {
+      const stats = await em.repo(GameStat).find({ game })
+      const globalStats = stats.filter((stat) => stat.global)
+
+      if (globalStats.length > 0) {
+        const promises = []
+
+        if (withMetrics === '1') {
+          promises.push(
+            ...globalStats.map((stat) =>
+              stat.loadMetrics({
+                clickhouse,
+                startDate: metricsStartDate,
+                endDate: metricsEndDate,
+                includeDevData,
+              }),
+            ),
+          )
+        }
+
+        if (!includeDevData) {
+          promises.push(
+            ...globalStats.map((stat) =>
+              stat.recalculateGlobalValue({ em, includeDevData: false }),
+            ),
+          )
+        }
+
+        await Promise.allSettled(promises)
+      }
+
+      return {
+        status: 200,
+        body: {
+          stats,
+        },
+      }
+    },
+  )
+}
 
 export const listRoute = protectedRoute({
   method: 'get',
@@ -15,52 +80,15 @@ export const listRoute = protectedRoute({
   middleware: withMiddleware(loadGame),
   handler: async (ctx) => {
     const { withMetrics, metricsStartDate, metricsEndDate } = ctx.state.validated.query
-    const em = ctx.em
-    const game = ctx.state.game
-    const includeDevData = ctx.state.includeDevData
 
-    return withResponseCache(
-      {
-        key: `${GameStat.getIndexCacheKey(game)}-${withMetrics}-${metricsStartDate}-${metricsEndDate}-${includeDevData ? 'dev' : 'no-dev'}`,
-      },
-      async () => {
-        const stats = await em.repo(GameStat).find({ game })
-        const globalStats = stats.filter((stat) => stat.global)
-
-        if (globalStats.length > 0) {
-          const promises = []
-
-          if (withMetrics === '1') {
-            promises.push(
-              ...globalStats.map((stat) =>
-                stat.loadMetrics({
-                  clickhouse: ctx.clickhouse,
-                  startDate: metricsStartDate,
-                  endDate: metricsEndDate,
-                  includeDevData,
-                }),
-              ),
-            )
-          }
-
-          if (!includeDevData) {
-            promises.push(
-              ...globalStats.map((stat) =>
-                stat.recalculateGlobalValue({ em, includeDevData: false }),
-              ),
-            )
-          }
-
-          await Promise.allSettled(promises)
-        }
-
-        return {
-          status: 200,
-          body: {
-            stats,
-          },
-        }
-      },
-    )
+    return listStatsHandler({
+      em: ctx.em,
+      game: ctx.state.game,
+      includeDevData: ctx.state.includeDevData,
+      clickhouse: ctx.clickhouse,
+      withMetrics,
+      metricsStartDate,
+      metricsEndDate,
+    })
   },
 })

--- a/tests/routes/admin/game-stat/list.test.ts
+++ b/tests/routes/admin/game-stat/list.test.ts
@@ -1,0 +1,31 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameStatFactory from '../../../fixtures/GameStatFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Game stat admin API - list', () => {
+  it('should return a list of game stats for a key with the read:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_STATS])
+
+    const stats = await new GameStatFactory([apiKey.game]).many(3)
+    await em.persist(stats).flush()
+
+    const res = await request(app)
+      .get('/admin/v1/game-stats')
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.stats).toHaveLength(stats.length)
+  })
+
+  it('should return 403 for a key missing the read:stats scope', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const res = await request(app)
+      .get('/admin/v1/game-stats')
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('read:stats')
+  })
+})


### PR DESCRIPTION
**New admin API endpoint for listing game stats**
- Added a `GET /admin/v1/game-stats` route accessible via admin API keys with the `READ_STATS` scope.
- The endpoint supports the same query parameters as the existing protected list route: `withMetrics`, `metricsStartDate`, and `metricsEndDate`.

**Shared handler extraction**
- The game stat list logic was extracted from the protected route handler into a reusable `listStatsHandler` function.
- Both the protected (dashboard) and admin API routes now delegate to this shared handler, avoiding duplication.

**Admin router updates**
- Registered the new list route on the game stat admin router.
- Changed the `docsKey` from `'adminGameStats'` to `'GameStatAdminAPI'`.