### PR TITLE
Add admin stats update route

### DIFF
--- a/src/routes/admin/game-stat/common.ts
+++ b/src/routes/admin/game-stat/common.ts
@@ -1,0 +1,20 @@
+import { Next } from 'koa'
+import GameStat from '../../../entities/game-stat.js'
+import { AdminAPIRouteContext } from '../../../lib/routing/context.js'
+
+type AdminGameStatRouteState = {
+  stat: GameStat
+}
+
+export async function loadStat(ctx: AdminAPIRouteContext<AdminGameStatRouteState>, next: Next) {
+  const { id } = ctx.params as { id: string }
+
+  const stat = await ctx.em.repo(GameStat).findOne({ id: Number(id), game: ctx.state.game })
+
+  if (!stat) {
+    return ctx.throw(404, 'Stat not found')
+  }
+
+  ctx.state.stat = stat
+  await next()
+}

--- a/src/routes/admin/game-stat/index.ts
+++ b/src/routes/admin/game-stat/index.ts
@@ -2,6 +2,7 @@ import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createStatAdminRoute } from './create.js'
 import { listStatsAdminRoute } from './list.js'
+import { updateStatAdminRoute } from './update.js'
 
 export function gameStatAdminRouter(router: Router) {
   adminRouter(
@@ -9,6 +10,7 @@ export function gameStatAdminRouter(router: Router) {
     ({ route }) => {
       route(createStatAdminRoute)
       route(listStatsAdminRoute)
+      route(updateStatAdminRoute)
     },
     { router, docsKey: 'GameStatAdminAPI' },
   )

--- a/src/routes/admin/game-stat/update.ts
+++ b/src/routes/admin/game-stat/update.ts
@@ -1,0 +1,22 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { updateStatBodySchema } from '../../protected/game-stat/common.js'
+import { updateStatHandler } from '../../protected/game-stat/update.js'
+import { loadStat } from './common.js'
+
+export const updateStatAdminRoute = adminRoute({
+  method: 'put',
+  path: '/:id',
+  schema: (z) => ({
+    body: updateStatBodySchema(z),
+  }),
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),
+  handler: (ctx) =>
+    updateStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
+      body: ctx.state.validated.body,
+      actor: ctx.state.key,
+    }),
+})

--- a/src/routes/protected/game-stat/update.ts
+++ b/src/routes/protected/game-stat/update.ts
@@ -1,9 +1,66 @@
+import { EntityManager } from '@mikro-orm/mysql'
+import { z } from 'zod'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
+import GameStat from '../../../entities/game-stat.js'
+import User from '../../../entities/user.js'
 import updateAllowedKeys from '../../../lib/entities/updateAllowedKeys.js'
 import handleSQLError from '../../../lib/errors/handleSQLError.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
+import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
-import { clearStatIndexResponseCache, loadStat, updateStatBodySchema } from './common.js'
+import { loadStat, updateStatBodySchema } from './common.js'
+
+export async function updateStatHandler({
+  em,
+  stat,
+  body,
+  actor,
+}: {
+  em: EntityManager
+  stat: GameStat
+  body: z.infer<ReturnType<typeof updateStatBodySchema>>
+  actor: User | AdminAPIKey
+}) {
+  const [, changedProperties] = updateAllowedKeys(stat, body, [
+    'name',
+    'global',
+    'maxChange',
+    'minValue',
+    'maxValue',
+    'defaultValue',
+    'minTimeBetweenUpdates',
+  ])
+
+  createGameActivity(em, {
+    actor,
+    game: stat.game,
+    type: GameActivityType.GAME_STAT_UPDATED,
+    extra: {
+      statInternalName: stat.internalName,
+      display: {
+        'Updated properties': changedProperties
+          .map((prop) => `${prop}: ${body[prop as keyof typeof body]}`)
+          .join(', '),
+      },
+    },
+  })
+
+  try {
+    await em.flush()
+  } catch (err) {
+    return handleSQLError(err as Error)
+  }
+
+  await deferClearResponseCache(GameStat.getIndexCacheKey(stat.game, true))
+
+  return {
+    status: 200,
+    body: {
+      stat,
+    },
+  }
+}
 
 export const updateRoute = protectedRoute({
   method: 'put',
@@ -11,46 +68,13 @@ export const updateRoute = protectedRoute({
   schema: (z) => ({
     body: updateStatBodySchema(z),
   }),
-  middleware: withMiddleware(loadStat, clearStatIndexResponseCache),
+  middleware: withMiddleware(loadStat),
   handler: async (ctx) => {
-    const em = ctx.em
-    const body = ctx.state.validated.body
-
-    const [stat, changedProperties] = updateAllowedKeys(ctx.state.stat, body, [
-      'name',
-      'global',
-      'maxChange',
-      'minValue',
-      'maxValue',
-      'defaultValue',
-      'minTimeBetweenUpdates',
-    ])
-
-    createGameActivity(em, {
+    return updateStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
+      body: ctx.state.validated.body,
       actor: ctx.state.user,
-      game: stat.game,
-      type: GameActivityType.GAME_STAT_UPDATED,
-      extra: {
-        statInternalName: stat.internalName,
-        display: {
-          'Updated properties': changedProperties
-            .map((prop) => `${prop}: ${body[prop as keyof typeof body]}`)
-            .join(', '),
-        },
-      },
     })
-
-    try {
-      await em.flush()
-    } catch (err) {
-      return handleSQLError(err as Error)
-    }
-
-    return {
-      status: 200,
-      body: {
-        stat,
-      },
-    }
   },
 })

--- a/tests/routes/admin/game-stat/update.test.ts
+++ b/tests/routes/admin/game-stat/update.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import GameStatFactory from '../../../fixtures/GameStatFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+
+describe('Game stat admin API - update', () => {
+  it('should update a stat for a key with the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .put(`/admin/v1/game-stats/${stat.id}`)
+      .send({
+        name: 'New name',
+        internalName: stat.internalName,
+        global: stat.global,
+        maxChange: stat.maxChange,
+        minValue: stat.minValue,
+        maxValue: stat.maxValue,
+        defaultValue: stat.defaultValue,
+        minTimeBetweenUpdates: stat.minTimeBetweenUpdates,
+      })
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.stat.name).toBe('New name')
+
+    const activity = await em.repo(GameActivity).findOneOrFail({
+      type: GameActivityType.GAME_STAT_UPDATED,
+      game: apiKey.game,
+      adminAPIKey: apiKey,
+    })
+    expect(activity.user).toBeNull()
+    expect(activity.adminAPIKey?.id).toBe(apiKey.id)
+  })
+
+  it('should return 403 for a key missing the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .put(`/admin/v1/game-stats/${stat.id}`)
+      .send({ name: 'New name' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:stats')
+  })
+
+  it('should return 404 for a stat that does not belong to the key game', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+    const [, otherGame] = await createOrganisationAndGame()
+
+    const stat = await new GameStatFactory([otherGame]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .put(`/admin/v1/game-stats/${stat.id}`)
+      .send({ name: 'New name' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Stat not found' })
+  })
+})


### PR DESCRIPTION
**Admin API for updating game stats**
- Added a new `PUT /admin/v1/game-stats/:id` endpoint allowing admin API keys with the `write:stats` scope to update game stat properties.
- Introduced `loadStat` middleware for admin routes that resolves a stat by ID scoped to the admin key's game, returning 404 if not found.

**Shared update logic across route tiers**
- Extracted the stat update handler into a reusable `updateStatHandler` function that accepts an `EntityManager`, stat, validated body, and actor (either a `User` or `AdminAPIKey`).
- Both the protected (dashboard) and admin API update routes now delegate to this shared handler, reducing duplication.

**Deferred cache invalidation**
- Replaced inline `clearStatIndexResponseCache` middleware with a `deferClearResponseCache` call inside the shared handler, deferring the cache clear until after the database flush succeeds.