### PR TITLE
Add admin stats delete route

### DIFF
--- a/src/routes/admin/game-stat/delete.ts
+++ b/src/routes/admin/game-stat/delete.ts
@@ -1,0 +1,17 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { deleteStatHandler } from '../../protected/game-stat/delete.js'
+import { loadStat } from './common.js'
+
+export const deleteStatAdminRoute = adminRoute({
+  method: 'delete',
+  path: '/:id',
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),
+  handler: (ctx) =>
+    deleteStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
+      actor: ctx.state.key,
+    }),
+})

--- a/src/routes/admin/game-stat/index.ts
+++ b/src/routes/admin/game-stat/index.ts
@@ -1,6 +1,7 @@
 import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createStatAdminRoute } from './create.js'
+import { deleteStatAdminRoute } from './delete.js'
 import { findStatAdminRoute } from './find.js'
 import { listStatsAdminRoute } from './list.js'
 import { updateStatAdminRoute } from './update.js'
@@ -13,6 +14,7 @@ export function gameStatAdminRouter(router: Router) {
       route(listStatsAdminRoute)
       route(findStatAdminRoute)
       route(updateStatAdminRoute)
+      route(deleteStatAdminRoute)
     },
     { router, docsKey: 'GameStatAdminAPI' },
   )

--- a/src/routes/protected/game-stat/delete.ts
+++ b/src/routes/protected/game-stat/delete.ts
@@ -1,38 +1,49 @@
+import { EntityManager } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import GameStat from '../../../entities/game-stat.js'
-import { UserType } from '../../../entities/user.js'
+import User, { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
-import { clearStatIndexResponseCache, loadStat } from './common.js'
+import { loadStat } from './common.js'
+
+export async function deleteStatHandler({
+  em,
+  stat,
+  actor,
+}: {
+  em: EntityManager
+  stat: GameStat
+  actor: User | AdminAPIKey
+}) {
+  createGameActivity(em, {
+    actor,
+    game: stat.game,
+    type: GameActivityType.GAME_STAT_DELETED,
+    extra: {
+      statInternalName: stat.internalName,
+    },
+  })
+
+  await em.remove(stat).flush()
+  await deferClearResponseCache(GameStat.getIndexCacheKey(stat.game, true))
+
+  return {
+    status: 204,
+  }
+}
 
 export const deleteRoute = protectedRoute({
   method: 'delete',
   path: '/:id',
-  middleware: withMiddleware(
-    userTypeGate([UserType.ADMIN], 'delete stats'),
-    loadStat,
-    clearStatIndexResponseCache,
-  ),
+  middleware: withMiddleware(userTypeGate([UserType.ADMIN], 'delete stats'), loadStat),
   handler: async (ctx) => {
-    const em = ctx.em
-    const stat = ctx.state.stat
-
-    createGameActivity(em, {
+    return deleteStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
       actor: ctx.state.user,
-      game: stat.game,
-      type: GameActivityType.GAME_STAT_DELETED,
-      extra: {
-        statInternalName: stat.internalName,
-      },
     })
-
-    await em.remove(stat).flush()
-    await deferClearResponseCache(GameStat.getIndexCacheKey(stat.game, true))
-
-    return {
-      status: 204,
-    }
   },
 })

--- a/tests/routes/admin/game-stat/delete.test.ts
+++ b/tests/routes/admin/game-stat/delete.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import GameStatFactory from '../../../fixtures/GameStatFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+
+describe('Game stat admin API - delete', () => {
+  it('should delete a stat for a key with the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game]).one()
+    await em.persist(stat).flush()
+
+    await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(204)
+
+    expect(await em.refresh(stat)).toBeNull()
+
+    const activity = await em.repo(GameActivity).findOneOrFail({
+      type: GameActivityType.GAME_STAT_DELETED,
+      game: apiKey.game,
+      adminAPIKey: apiKey,
+    })
+    expect(activity.user).toBeNull()
+    expect(activity.adminAPIKey?.id).toBe(apiKey.id)
+  })
+
+  it('should return 403 for a key missing the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:stats')
+  })
+
+  it('should return 404 for a stat that does not belong to the key game', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+    const [, otherGame] = await createOrganisationAndGame()
+
+    const stat = await new GameStatFactory([otherGame]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Stat not found' })
+  })
+})

--- a/tests/routes/protected/game-stat/delete.test.ts
+++ b/tests/routes/protected/game-stat/delete.test.ts
@@ -30,6 +30,7 @@ describe('Game stat - delete', () => {
       })
 
       if (statusCode === 204) {
+        expect(await em.refresh(stat)).toBeNull()
         expect(activity).not.toBeNull()
       } else {
         expect(activity).toBeNull()


### PR DESCRIPTION
**Admin API for game stat deletion**
- Added a new DELETE endpoint at `/admin/v1/game-stats/:id` allowing admin API keys to delete game stats, gated by the `WRITE_STATS` scope.

**Shared deletion logic**
- Extracted the stat deletion handler from the protected route into a reusable `deleteStatHandler` function that accepts either a `User` or `AdminAPIKey` as the actor, enabling both the protected and admin routes to share the same business logic (activity logging, entity removal, cache invalidation).