### PR TITLE
Add admin stats reset route

### DIFF
--- a/src/lib/validation/resetModeValidation.ts
+++ b/src/lib/validation/resetModeValidation.ts
@@ -1,6 +1,8 @@
 export const resetModes = ['all', 'live', 'dev'] as const
 
-export function translateResetMode(resetMode: (typeof resetModes)[number]) {
+export type ResetMode = (typeof resetModes)[number]
+
+export function translateResetMode(resetMode: ResetMode) {
   switch (resetMode) {
     case 'all':
       return 'All players'

--- a/src/routes/admin/game-stat/index.ts
+++ b/src/routes/admin/game-stat/index.ts
@@ -4,6 +4,7 @@ import { createStatAdminRoute } from './create.js'
 import { deleteStatAdminRoute } from './delete.js'
 import { findStatAdminRoute } from './find.js'
 import { listStatsAdminRoute } from './list.js'
+import { resetStatAdminRoute } from './reset.js'
 import { updateStatAdminRoute } from './update.js'
 
 export function gameStatAdminRouter(router: Router) {
@@ -15,6 +16,7 @@ export function gameStatAdminRouter(router: Router) {
       route(findStatAdminRoute)
       route(updateStatAdminRoute)
       route(deleteStatAdminRoute)
+      route(resetStatAdminRoute)
     },
     { router, docsKey: 'GameStatAdminAPI' },
   )

--- a/src/routes/admin/game-stat/reset.ts
+++ b/src/routes/admin/game-stat/reset.ts
@@ -1,0 +1,34 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { resetModes } from '../../../lib/validation/resetModeValidation.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { resetStatHandler } from '../../protected/game-stat/reset.js'
+import { loadStat } from './common.js'
+
+export const resetStatAdminRoute = adminRoute({
+  method: 'delete',
+  path: '/:id/player-stats',
+  schema: (z) => ({
+    query: z.object({
+      mode: z
+        .enum(resetModes, {
+          error: `Mode must be one of: ${resetModes.join(', ')}`,
+        })
+        .optional()
+        .default('all'),
+    }),
+  }),
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),
+  handler: (ctx) => {
+    const { mode } = ctx.state.validated.query
+
+    return resetStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
+      actor: ctx.state.key,
+      mode,
+      clickhouse: ctx.clickhouse,
+      redis: ctx.redis,
+    })
+  },
+})

--- a/src/routes/protected/game-stat/reset.ts
+++ b/src/routes/protected/game-stat/reset.ts
@@ -1,16 +1,145 @@
+import type { ClickHouseClient } from '@clickhouse/client'
+import type { Redis } from 'ioredis'
 import { FilterQuery } from '@mikro-orm/mysql'
+import { EntityManager } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import GameStat from '../../../entities/game-stat.js'
 import PlayerAlias from '../../../entities/player-alias.js'
 import PlayerGameStat from '../../../entities/player-game-stat.js'
-import { UserType } from '../../../entities/user.js'
+import User, { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { streamByCursor } from '../../../lib/perf/streamByCursor.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
-import { resetModes, translateResetMode } from '../../../lib/validation/resetModeValidation.js'
+import {
+  ResetMode,
+  resetModes,
+  translateResetMode,
+} from '../../../lib/validation/resetModeValidation.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadStat } from './common.js'
+
+export async function resetStatHandler({
+  em,
+  stat,
+  actor,
+  mode,
+  clickhouse,
+  redis,
+}: {
+  em: EntityManager
+  stat: GameStat
+  actor: User | AdminAPIKey
+  mode: ResetMode
+  clickhouse: ClickHouseClient
+  redis: Redis
+}) {
+  const where: FilterQuery<PlayerGameStat> = { stat }
+
+  if (mode === 'dev') {
+    where.player = {
+      devBuild: true,
+    }
+  } else if (mode === 'live') {
+    where.player = {
+      devBuild: false,
+    }
+  }
+
+  const deletedCount = await em.fork().transactional(async (trx) => {
+    const playerIds = await trx.repo(PlayerGameStat).find(where, {
+      fields: ['player.id'],
+    })
+
+    const deletedCount = await trx.repo(PlayerGameStat).nativeDelete(where)
+
+    await stat.recalculateGlobalValue({
+      em: trx,
+      includeDevData: mode !== 'dev',
+      devOnly: mode === 'live',
+    })
+    await trx.repo(GameStat).nativeUpdate(stat.id, { globalValue: stat.globalValue })
+
+    createGameActivity(trx, {
+      actor,
+      game: stat.game,
+      type: GameActivityType.GAME_STAT_RESET,
+      extra: {
+        statInternalName: stat.internalName,
+        display: {
+          'Reset mode': translateResetMode(mode),
+          'Deleted count': deletedCount,
+        },
+      },
+    })
+
+    const aliasStream = streamByCursor<PlayerAlias, never, 'id'>(async (batchSize, after) => {
+      return trx.repo(PlayerAlias).findByCursor({
+        where: {
+          player: { id: playerIds.map((p) => p.player.id) },
+        },
+        first: batchSize,
+        after,
+        orderBy: { id: 'asc' },
+        fields: ['id'],
+        strategy: 'joined',
+      })
+    }, 1000)
+
+    const query = `
+      DELETE FROM player_game_stat_snapshots
+      WHERE
+        game_stat_id = {statId:UInt32}
+        AND player_alias_id IN ({aliasIds:Array(UInt32)})
+    `
+    const aliasIds: number[] = []
+    const CLICKHOUSE_BATCH_SIZE = 100
+
+    for await (const alias of aliasStream) {
+      aliasIds.push(alias.id)
+
+      if (aliasIds.length >= CLICKHOUSE_BATCH_SIZE) {
+        const batchIds = aliasIds.splice(0, CLICKHOUSE_BATCH_SIZE)
+        await clickhouse.command({
+          query,
+          query_params: {
+            statId: stat.id,
+            aliasIds: batchIds,
+          },
+        })
+      }
+    }
+
+    // delete any remaining unspliced aliases
+    if (aliasIds.length > 0) {
+      await clickhouse.command({
+        query,
+        query_params: {
+          statId: stat.id,
+          aliasIds,
+        },
+      })
+    }
+
+    return deletedCount
+  })
+
+  await em.refresh(stat)
+  await redis.set(GameStat.getGlobalValueCacheKey(stat.id), stat.globalValue)
+
+  await Promise.allSettled([
+    deferClearResponseCache(GameStat.getIndexCacheKey(stat.game, true)),
+    deferClearResponseCache(PlayerGameStat.getCacheKeyForStat(stat, true)),
+  ])
+
+  return {
+    status: 200,
+    body: {
+      deletedCount,
+    },
+  }
+}
 
 export const resetRoute = protectedRoute({
   method: 'delete',
@@ -28,113 +157,14 @@ export const resetRoute = protectedRoute({
   middleware: withMiddleware(userTypeGate([UserType.ADMIN], 'reset stats'), loadStat),
   handler: async (ctx) => {
     const { mode } = ctx.state.validated.query
-    const em = ctx.em
-    const stat = ctx.state.stat
 
-    const where: FilterQuery<PlayerGameStat> = { stat }
-
-    if (mode === 'dev') {
-      where.player = {
-        devBuild: true,
-      }
-    } else if (mode === 'live') {
-      where.player = {
-        devBuild: false,
-      }
-    }
-
-    const deletedCount = await em.fork().transactional(async (trx) => {
-      const playerIds = await trx.repo(PlayerGameStat).find(where, {
-        fields: ['player.id'],
-      })
-
-      const deletedCount = await trx.repo(PlayerGameStat).nativeDelete(where)
-
-      await stat.recalculateGlobalValue({
-        em: trx,
-        includeDevData: mode !== 'dev',
-        devOnly: mode === 'live',
-      })
-      await trx.repo(GameStat).nativeUpdate(stat.id, { globalValue: stat.globalValue })
-
-      createGameActivity(trx, {
-        actor: ctx.state.user,
-        game: stat.game,
-        type: GameActivityType.GAME_STAT_RESET,
-        extra: {
-          statInternalName: stat.internalName,
-          display: {
-            'Reset mode': translateResetMode(mode),
-            'Deleted count': deletedCount,
-          },
-        },
-      })
-
-      const clickhouse = ctx.clickhouse
-      const aliasStream = streamByCursor<PlayerAlias, never, 'id'>(async (batchSize, after) => {
-        return trx.repo(PlayerAlias).findByCursor({
-          where: {
-            player: { id: playerIds.map((p) => p.player.id) },
-          },
-          first: batchSize,
-          after,
-          orderBy: { id: 'asc' },
-          fields: ['id'],
-          strategy: 'joined',
-        })
-      }, 1000)
-
-      const query = `
-        DELETE FROM player_game_stat_snapshots
-        WHERE
-          game_stat_id = {statId:UInt32}
-          AND player_alias_id IN ({aliasIds:Array(UInt32)})
-      `
-      const aliasIds: number[] = []
-      const CLICKHOUSE_BATCH_SIZE = 100
-
-      for await (const alias of aliasStream) {
-        aliasIds.push(alias.id)
-
-        if (aliasIds.length >= CLICKHOUSE_BATCH_SIZE) {
-          const batchIds = aliasIds.splice(0, CLICKHOUSE_BATCH_SIZE)
-          await clickhouse.command({
-            query,
-            query_params: {
-              statId: stat.id,
-              aliasIds: batchIds,
-            },
-          })
-        }
-      }
-
-      // delete any remaining unspliced aliases
-      if (aliasIds.length > 0) {
-        await clickhouse.command({
-          query,
-          query_params: {
-            statId: stat.id,
-            aliasIds,
-          },
-        })
-      }
-
-      return deletedCount
+    return resetStatHandler({
+      em: ctx.em,
+      stat: ctx.state.stat,
+      actor: ctx.state.user,
+      mode,
+      clickhouse: ctx.clickhouse,
+      redis: ctx.redis,
     })
-
-    await em.refresh(stat)
-    await ctx.redis.set(GameStat.getGlobalValueCacheKey(stat.id), stat.globalValue)
-
-    await Promise.allSettled([
-      deferClearResponseCache(GameStat.getIndexCacheKey(stat.game, true)),
-      deferClearResponseCache(PlayerGameStat.getCacheKeyForStat(stat, true)),
-    ])
-
-    return {
-      status: 200,
-      body: {
-        deletedCount,
-      },
-    }
   },
 })

--- a/tests/routes/admin/game-stat/reset.test.ts
+++ b/tests/routes/admin/game-stat/reset.test.ts
@@ -1,0 +1,81 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import PlayerGameStat from '../../../../src/entities/player-game-stat.js'
+import GameStatFactory from '../../../fixtures/GameStatFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import PlayerGameStatFactory from '../../../fixtures/PlayerGameStatFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+
+describe('Game stat admin API - reset', () => {
+  it('should reset all player stats for a key with the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game])
+      .state(() => ({ global: true, globalValue: 500, defaultValue: 0 }))
+      .one()
+
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const playerStats = await Promise.all(
+      players.map((player) =>
+        new PlayerGameStatFactory()
+          .construct(player, stat)
+          .state(() => ({ value: 50 }))
+          .one(),
+      ),
+    )
+    await em.persist(playerStats).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}/player-stats`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.deletedCount).toBe(3)
+
+    const remainingPlayerStats = await em.repo(PlayerGameStat).find({ stat })
+    expect(remainingPlayerStats).toHaveLength(0)
+
+    await em.refresh(stat)
+    expect(stat.globalValue).toBe(0)
+
+    const activity = await em.repo(GameActivity).findOneOrFail({
+      type: GameActivityType.GAME_STAT_RESET,
+      game: apiKey.game,
+      adminAPIKey: apiKey,
+    })
+    expect(activity.adminAPIKey?.id).toBe(apiKey.id)
+    expect(activity.extra.display?.['Reset mode']).toBe('All players')
+    expect(activity.extra.display?.['Deleted count']).toBe(3)
+  })
+
+  it('should return 403 for a key missing the write:stats scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}/player-stats`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:stats')
+  })
+
+  it('should return 404 for a stat that does not belong to the key game', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+    const [, otherGame] = await createOrganisationAndGame()
+
+    const stat = await new GameStatFactory([otherGame]).one()
+    await em.persist(stat).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/game-stats/${stat.id}/player-stats`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Stat not found' })
+  })
+})


### PR DESCRIPTION
**Admin API for stat resets**

- New admin endpoint (`DELETE /admin/v1/game-stats/:id/player-stats`) allowing API keys with the `write:stats` scope to reset player game stats.

**Shared reset logic**

- Extracted the stat reset handler from the protected (dashboard) route into a standalone `resetStatHandler` function, reused by both the protected and admin routes to avoid duplication.

**Type export**

- Exported a `ResetMode` type from the validation module so it can be referenced by the extracted handler's parameter types.