### PR TITLE
Add docs to admin stats routes

### DIFF
--- a/src/routes/admin/game-stat/create.ts
+++ b/src/routes/admin/game-stat/create.ts
@@ -3,9 +3,11 @@ import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { createStatBodySchema } from '../../protected/game-stat/common.js'
 import { createStatHandler } from '../../protected/game-stat/create.js'
+import { createDocs } from './docs.js'
 
 export const createStatAdminRoute = adminRoute({
   method: 'post',
+  docs: createDocs,
   schema: (z) => ({
     body: createStatBodySchema(z),
   }),

--- a/src/routes/admin/game-stat/delete.ts
+++ b/src/routes/admin/game-stat/delete.ts
@@ -1,12 +1,20 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { deleteStatHandler } from '../../protected/game-stat/delete.js'
 import { loadStat } from './common.js'
+import { deleteDocs } from './docs.js'
 
 export const deleteStatAdminRoute = adminRoute({
   method: 'delete',
   path: '/:id',
+  docs: deleteDocs,
+  schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the stat' }),
+    }),
+  }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),
   handler: (ctx) =>
     deleteStatHandler({

--- a/src/routes/admin/game-stat/docs.ts
+++ b/src/routes/admin/game-stat/docs.ts
@@ -1,0 +1,165 @@
+import { RouteDocs } from '../../../lib/docs/docs-registry.js'
+
+const statSample = {
+  id: 4,
+  internalName: 'gold-collected',
+  name: 'Gold collected',
+  global: true,
+  globalValue: 5839,
+  defaultValue: 0,
+  maxChange: null,
+  minValue: 0,
+  maxValue: null,
+  minTimeBetweenUpdates: 5,
+  createdAt: '2026-08-15T12:45:39.409Z',
+  updatedAt: '2026-08-15T12:49:14.315Z',
+}
+
+const statWithMetricsSample = {
+  ...statSample,
+  metrics: {
+    globalCount: 5,
+    globalValue: {
+      minValue: 5839,
+      maxValue: 6052,
+      medianValue: 5912,
+      averageValue: 5934,
+      averageChange: 42.6,
+    },
+    playerValue: {
+      minValue: 5839,
+      maxValue: 6052,
+      medianValue: 5912,
+      averageValue: 5934,
+    },
+  },
+}
+
+export const createDocs = {
+  description: 'Create a game stat',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        internalName: 'gold-collected',
+        name: 'Gold collected',
+        global: true,
+        defaultValue: 0,
+        minTimeBetweenUpdates: 5,
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        stat: statSample,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
+export const listDocs = {
+  description: 'List all stats',
+  samples: [
+    {
+      title: 'Sample response',
+      sample: {
+        stats: [
+          statSample,
+          {
+            id: 7,
+            internalName: 'silver-collected',
+            name: 'Silver collected',
+            global: true,
+            globalValue: 15874,
+            defaultValue: 0,
+            maxChange: 99,
+            minValue: 0,
+            maxValue: 99,
+            minTimeBetweenUpdates: 5,
+            createdAt: '2026-08-15T12:50:21.803Z',
+            updatedAt: '2026-08-15T12:52:47.511Z',
+          },
+        ],
+      },
+    },
+    {
+      title: 'Sample request with metrics',
+      sample: {
+        url: '/admin/v1/game-stats?withMetrics=1&metricsStartDate=2026-08-15&metricsEndDate=2026-08-15T00%3A56%3A00.000Z',
+        query: {
+          withMetrics: '1',
+          metricsStartDate: '2026-08-15',
+          metricsEndDate: '2026-08-15T00:56:00.000Z',
+        },
+      },
+    },
+    {
+      title: 'Sample response with metrics',
+      sample: {
+        stats: [statWithMetricsSample],
+      },
+    },
+  ],
+} satisfies RouteDocs
+
+export const findDocs = {
+  description: 'Find a stat',
+  samples: [
+    {
+      title: 'Sample response',
+      sample: {
+        stat: statSample,
+      },
+    },
+    {
+      title: 'Sample response with metrics',
+      sample: {
+        stat: statWithMetricsSample,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
+export const updateDocs = {
+  description: 'Update a game stat',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        name: 'Gold collected',
+        maxValue: 100000,
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        stat: statSample,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
+export const deleteDocs = {
+  description: 'Delete a game stat',
+} satisfies RouteDocs
+
+export const resetDocs = {
+  description: 'Reset the player stats for a stat',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        url: '/admin/v1/game-stats/4/player-stats?mode=all',
+        query: {
+          mode: 'all',
+        },
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        deletedCount: 3,
+      },
+    },
+  ],
+} satisfies RouteDocs

--- a/src/routes/admin/game-stat/find.ts
+++ b/src/routes/admin/game-stat/find.ts
@@ -1,16 +1,29 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { loadStat } from './common.js'
+import { findDocs } from './docs.js'
 
 export const findStatAdminRoute = adminRoute({
   method: 'get',
   path: '/:id',
+  docs: findDocs,
   schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the stat' }),
+    }),
     query: z.object({
-      withMetrics: z.string().optional(),
-      metricsStartDate: z.string().optional(),
-      metricsEndDate: z.string().optional(),
+      withMetrics: z
+        .string()
+        .optional()
+        .meta({ description: 'Set to 1 to include metrics for global stats' }),
+      metricsStartDate: z.string().optional().meta({
+        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+      }),
+      metricsEndDate: z.string().optional().meta({
+        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+      }),
     }),
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_STATS]), loadStat),

--- a/src/routes/admin/game-stat/list.ts
+++ b/src/routes/admin/game-stat/list.ts
@@ -2,14 +2,23 @@ import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { listStatsHandler } from '../../protected/game-stat/list.js'
+import { listDocs } from './docs.js'
 
 export const listStatsAdminRoute = adminRoute({
   method: 'get',
+  docs: listDocs,
   schema: (z) => ({
     query: z.object({
-      withMetrics: z.string().optional(),
-      metricsStartDate: z.string().optional(),
-      metricsEndDate: z.string().optional(),
+      withMetrics: z
+        .string()
+        .optional()
+        .meta({ description: 'Set to 1 to include metrics for global stats' }),
+      metricsStartDate: z.string().optional().meta({
+        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+      }),
+      metricsEndDate: z.string().optional().meta({
+        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+      }),
     }),
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_STATS])),

--- a/src/routes/admin/game-stat/reset.ts
+++ b/src/routes/admin/game-stat/reset.ts
@@ -1,21 +1,28 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
 import { resetModes } from '../../../lib/validation/resetModeValidation.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { resetStatHandler } from '../../protected/game-stat/reset.js'
 import { loadStat } from './common.js'
+import { resetDocs } from './docs.js'
 
 export const resetStatAdminRoute = adminRoute({
   method: 'delete',
   path: '/:id/player-stats',
+  docs: resetDocs,
   schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the stat' }),
+    }),
     query: z.object({
       mode: z
         .enum(resetModes, {
           error: `Mode must be one of: ${resetModes.join(', ')}`,
         })
         .optional()
-        .default('all'),
+        .default('all')
+        .meta({ description: 'Which players to reset: all, live or dev' }),
     }),
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),

--- a/src/routes/admin/game-stat/update.ts
+++ b/src/routes/admin/game-stat/update.ts
@@ -1,14 +1,20 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { updateStatBodySchema } from '../../protected/game-stat/common.js'
 import { updateStatHandler } from '../../protected/game-stat/update.js'
 import { loadStat } from './common.js'
+import { updateDocs } from './docs.js'
 
 export const updateStatAdminRoute = adminRoute({
   method: 'put',
   path: '/:id',
+  docs: updateDocs,
   schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the stat' }),
+    }),
     body: updateStatBodySchema(z),
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),

--- a/src/routes/protected/game-stat/common.ts
+++ b/src/routes/protected/game-stat/common.ts
@@ -1,6 +1,6 @@
 import { Next } from 'koa'
 import assert from 'node:assert'
-import { RefinementCtx, z } from 'zod'
+import { RefinementCtx, ZodType, z } from 'zod'
 import GameStat from '../../../entities/game-stat.js'
 import PlayerGameStat from '../../../entities/player-game-stat.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
@@ -61,27 +61,46 @@ function validateStatBody(data: StatSchemaData, ctx: RefinementCtx) {
 
 function statFields(z: Z) {
   return {
-    name: z.string(),
-    global: z.boolean(),
-    maxChange: z.number().nullable().optional(),
-    minValue: z.number().nullable().optional(),
-    maxValue: z.number().nullable().optional(),
-    defaultValue: z.number(),
-    minTimeBetweenUpdates: z.number().min(0),
+    name: z.string().meta({ description: 'The display name of the stat' }),
+    global: z
+      .boolean()
+      .meta({ description: 'Whether the stat value is shared across all players' }),
+    maxChange: z.number().nullable().optional().meta({
+      description: 'The maximum allowed change to the stat per update',
+    }),
+    minValue: z.number().nullable().optional().meta({
+      description: 'The minimum value the stat can be set to',
+    }),
+    maxValue: z.number().nullable().optional().meta({
+      description: 'The maximum value the stat can be set to',
+    }),
+    defaultValue: z.number().meta({ description: 'The default value for the stat' }),
+    minTimeBetweenUpdates: z.number().min(0).meta({
+      description: 'The minimum time in seconds between updates',
+    }),
   }
 }
 
 export function createStatBodySchema(z: Z) {
   return z
     .object({
-      internalName: z.string(),
+      internalName: z.string().meta({ description: 'The internal name of the stat' }),
       ...statFields(z),
     })
     .superRefine(validateStatBody)
 }
 
+function optionalFields(fields: Record<string, ZodType>): Record<string, ZodType> {
+  const result: Record<string, ZodType> = {}
+  for (const [key, schema] of Object.entries(fields)) {
+    const description = schema.meta?.()?.description
+    result[key] = schema.optional().meta({ description })
+  }
+  return result
+}
+
 export function updateStatBodySchema(z: Z) {
-  return z.object(statFields(z)).partial().superRefine(validateStatBody)
+  return z.object(optionalFields(statFields(z))).superRefine(validateStatBody)
 }
 
 export async function loadStat(ctx: StatRouteContext, next: Next) {


### PR DESCRIPTION
**API documentation for game stat endpoints**
- Added descriptive metadata (`meta({ description })`) to all Zod schema fields across game stat routes (create, update, list, find, reset, delete).
- Introduced a new `docs.ts` file containing structured documentation objects with descriptions and sample request/response payloads for each game stat admin endpoint.
- Wired `docs` properties into each admin route definition so documentation is co-located with the route.

**Schema improvements for admin game stat routes**
- Added explicit `route` schema with `id: numericStringSchema` to delete, find, update, and reset admin routes, which previously lacked route parameter validation.
- Extracted a shared `optionalFields` helper to make all stat fields optional in update schemas while preserving their descriptions.
- Improved query parameter descriptions for `withMetrics`, `metricsStartDate`, `metricsEndDate`, and reset `mode`.