### PR TITLE
Add admin leaderboard create route

### DIFF
--- a/src/config/admin-api-routes.ts
+++ b/src/config/admin-api-routes.ts
@@ -2,6 +2,7 @@ import Koa from 'koa'
 import Router from 'koa-tree-router'
 import { adminAPIKeyMiddleware } from '../middleware/admin-api-key-middleware.js'
 import { gameStatAdminRouter } from '../routes/admin/game-stat/index.js'
+import { leaderboardAdminRouter } from '../routes/admin/leaderboard/index.js'
 
 export function configureAdminAPIRoutes(app: Koa) {
   app.use(adminAPIKeyMiddleware)
@@ -9,6 +10,7 @@ export function configureAdminAPIRoutes(app: Koa) {
   const mainRouter = new Router()
 
   gameStatAdminRouter(mainRouter)
+  leaderboardAdminRouter(mainRouter)
 
   app.use(mainRouter.routes())
 }

--- a/src/entities/admin-api-key.ts
+++ b/src/entities/admin-api-key.ts
@@ -5,6 +5,8 @@ import User from './user.js'
 export enum AdminAPIKeyScope {
   READ_STATS = 'read:stats',
   WRITE_STATS = 'write:stats',
+  READ_LEADERBOARDS = 'read:leaderboards',
+  WRITE_LEADERBOARDS = 'write:leaderboards',
   FULL_ACCESS = '*',
 }
 

--- a/src/routes/admin/leaderboard/create.ts
+++ b/src/routes/admin/leaderboard/create.ts
@@ -1,0 +1,31 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { createLeaderboardBodySchema } from '../../protected/leaderboard/common.js'
+import { createLeaderboardHandler } from '../../protected/leaderboard/create.js'
+import { createDocs } from './docs.js'
+
+export const createLeaderboardAdminRoute = adminRoute({
+  method: 'post',
+  docs: createDocs,
+  schema: (z) => ({
+    body: createLeaderboardBodySchema(z),
+  }),
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_LEADERBOARDS])),
+  handler: (ctx) => {
+    const { internalName, name, sortMode, unique, refreshInterval, uniqueByProps } =
+      ctx.state.validated.body
+
+    return createLeaderboardHandler({
+      em: ctx.em,
+      game: ctx.state.game,
+      actor: ctx.state.key,
+      internalName,
+      name,
+      sortMode,
+      unique,
+      refreshInterval,
+      uniqueByProps,
+    })
+  },
+})

--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -1,0 +1,35 @@
+import { RouteDocs } from '../../../lib/docs/docs-registry.js'
+
+const leaderboardSample = {
+  id: 4,
+  internalName: 'highscores',
+  name: 'Highscores',
+  sortMode: 'desc',
+  unique: true,
+  uniqueByProps: false,
+  refreshInterval: 'never',
+  createdAt: '2026-08-15T12:45:39.409Z',
+  updatedAt: '2026-08-15T12:49:14.315Z',
+}
+
+export const createDocs = {
+  description: 'Create a leaderboard',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        internalName: 'highscores',
+        name: 'Highscores',
+        sortMode: 'desc',
+        unique: true,
+        refreshInterval: 'never',
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        leaderboard: leaderboardSample,
+      },
+    },
+  ],
+} satisfies RouteDocs

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -1,0 +1,13 @@
+import type Router from 'koa-tree-router'
+import { adminRouter } from '../../../lib/routing/router.js'
+import { createLeaderboardAdminRoute } from './create.js'
+
+export function leaderboardAdminRouter(router: Router) {
+  adminRouter(
+    '/admin/v1/leaderboards',
+    ({ route }) => {
+      route(createLeaderboardAdminRoute)
+    },
+    { router, docsKey: 'LeaderboardAdminAPI' },
+  )
+}

--- a/src/routes/protected/leaderboard/common.ts
+++ b/src/routes/protected/leaderboard/common.ts
@@ -1,9 +1,42 @@
 import { Next } from 'koa'
-import Leaderboard from '../../../entities/leaderboard.js'
+import { z } from 'zod'
+import Leaderboard, {
+  LeaderboardRefreshInterval,
+  LeaderboardSortMode,
+} from '../../../entities/leaderboard.js'
 import { ProtectedRouteContext } from '../../../lib/routing/context.js'
 import { GameRouteState } from '../../../middleware/game-middleware.js'
 
 type LeaderboardRouteContext = ProtectedRouteContext<GameRouteState & { leaderboard: Leaderboard }>
+
+const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
+const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
+
+export function createLeaderboardBodySchema(zod: typeof z) {
+  return zod.object({
+    internalName: zod.string().meta({ description: 'The internal name of the leaderboard' }),
+    name: zod.string().meta({ description: 'The display name of the leaderboard' }),
+    sortMode: zod
+      .enum(LeaderboardSortMode, {
+        error: `Sort mode must be one of ${sortModeValues}`,
+      })
+      .meta({ description: 'How entries are sorted: asc or desc' }),
+    unique: zod.boolean().meta({
+      description: 'Whether each player can only have a single entry',
+    }),
+    refreshInterval: zod
+      .enum(LeaderboardRefreshInterval, {
+        error: `Refresh interval must be one of ${refreshIntervalValues}`,
+      })
+      .optional()
+      .meta({
+        description: 'How often the leaderboard resets: never, daily, weekly, monthly or yearly',
+      }),
+    uniqueByProps: zod.boolean().optional().meta({
+      description: 'Whether entries are unique based on their props',
+    }),
+  })
+}
 
 export function loadLeaderboard(withEntries: boolean = false) {
   return async (ctx: LeaderboardRouteContext, next: Next) => {

--- a/src/routes/protected/leaderboard/create.ts
+++ b/src/routes/protected/leaderboard/create.ts
@@ -1,4 +1,5 @@
 import { EntityManager } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import Game from '../../../entities/game.js'
 import Leaderboard, {
@@ -13,11 +14,12 @@ import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
+import { createLeaderboardBodySchema } from './common.js'
 
 type CreateLeaderboardParams = {
   em: EntityManager
   game: Game
-  user: User
+  actor: User | AdminAPIKey
   internalName: string
   name: string
   sortMode: LeaderboardSortMode
@@ -29,7 +31,7 @@ type CreateLeaderboardParams = {
 export async function createLeaderboardHandler({
   em,
   game,
-  user,
+  actor,
   internalName,
   name,
   sortMode,
@@ -57,7 +59,7 @@ export async function createLeaderboardHandler({
   leaderboard.uniqueByProps = uniqueByProps
 
   createGameActivity(em, {
-    actor: user,
+    actor,
     game: leaderboard.game,
     type: GameActivityType.LEADERBOARD_CREATED,
     extra: {
@@ -79,26 +81,10 @@ export async function createLeaderboardHandler({
   }
 }
 
-const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
-const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
-
 export const createRoute = protectedRoute({
   method: 'post',
   schema: (z) => ({
-    body: z.object({
-      internalName: z.string(),
-      name: z.string(),
-      sortMode: z.enum(LeaderboardSortMode, {
-        error: `Sort mode must be one of ${sortModeValues}`,
-      }),
-      unique: z.boolean(),
-      refreshInterval: z
-        .enum(LeaderboardRefreshInterval, {
-          error: `Refresh interval must be one of ${refreshIntervalValues}`,
-        })
-        .optional(),
-      uniqueByProps: z.boolean().optional(),
-    }),
+    body: createLeaderboardBodySchema(z),
   }),
   middleware: withMiddleware(
     userTypeGate([UserType.ADMIN, UserType.DEV], 'create leaderboards'),
@@ -111,7 +97,7 @@ export const createRoute = protectedRoute({
     return createLeaderboardHandler({
       em: ctx.em,
       game: ctx.state.game,
-      user: ctx.state.user,
+      actor: ctx.state.user,
       internalName,
       name,
       sortMode,

--- a/tests/routes/admin/leaderboard/create.test.ts
+++ b/tests/routes/admin/leaderboard/create.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - create', () => {
+  it('should create a leaderboard for a key with the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const res = await request(app)
+      .post('/admin/v1/leaderboards')
+      .send({
+        internalName: 'highscores',
+        name: 'Highscores',
+        sortMode: 'desc',
+        unique: true,
+        refreshInterval: 'never',
+      })
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.leaderboard.internalName).toBe('highscores')
+    expect(res.body.leaderboard.name).toBe('Highscores')
+
+    const activity = await em.repo(GameActivity).findOneOrFail({
+      type: GameActivityType.LEADERBOARD_CREATED,
+      game: apiKey.game,
+      adminAPIKey: apiKey,
+    })
+    expect(activity.adminAPIKey?.id).toBe(apiKey.id)
+  })
+
+  it('should return 403 for a key missing the write:leaderboards scope', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_STATS])
+
+    const res = await request(app)
+      .post('/admin/v1/leaderboards')
+      .send({
+        internalName: 'highscores',
+        name: 'Highscores',
+        sortMode: 'desc',
+        unique: true,
+        refreshInterval: 'never',
+      })
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:leaderboards')
+  })
+})


### PR DESCRIPTION
**Admin API for leaderboards**

- Added a new admin API endpoint (`POST /admin/v1/leaderboards`) that allows creating leaderboards via admin API keys, reusing the existing protected route handler logic.
- Introduced two new admin API key scopes: `READ_LEADERBOARDS` and `WRITE_LEADERBOARDS` to control access to leaderboard operations.

**Shared leaderboard creation logic**

- Extracted the leaderboard creation body schema into a shared `createLeaderboardBodySchema` function in `common.ts`, used by both the protected (dashboard) route and the new admin route.
- Refactored the `createLeaderboardHandler` to accept a generic `actor` parameter (`User | AdminAPIKey`) instead of only `User`, enabling it to be called from both user-authenticated and admin-API-key-authenticated contexts.
- The admin route's create handler delegates directly to the existing `createLeaderboardHandler`, avoiding duplication.