### PR TITLE
Fix flaky Steamworks leaderboard test

### DIFF
--- a/tests/routes/protected/leaderboard/steamworks-update-entry.test.ts
+++ b/tests/routes/protected/leaderboard/steamworks-update-entry.test.ts
@@ -220,7 +220,7 @@ describe('Leaderboard - steamworks update entry', () => {
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
-      .state(() => ({ hidden: randBoolean() }))
+      .state(() => ({ hidden: false }))
       .one()
 
     const config = await new IntegrationConfigFactory()
@@ -233,7 +233,7 @@ describe('Leaderboard - steamworks update entry', () => {
 
     await request(app)
       .patch(`/games/${game.id}/leaderboards/${leaderboard.id}/entries/${entry.id}`)
-      .send({ hidden: !entry.hidden })
+      .send({ hidden: true })
       .auth(token, { type: 'bearer' })
       .expect(200)
 


### PR DESCRIPTION
**Test determinism improvement**
- Replaced random boolean generation (`randBoolean()`) with an explicit `false` value for the `hidden` field in leaderboard entry test setup.
- Changed the update payload from dynamically toggling the current value (`!entry.hidden`) to always setting it to `true`, ensuring predictable test behavior.