### PR TITLE
Add admin API route for listing leaderboards

### DIFF
--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -33,3 +33,37 @@ export const createDocs = {
     },
   ],
 } satisfies RouteDocs
+
+export const listDocs = {
+  description: 'List all leaderboards',
+  samples: [
+    {
+      title: 'Sample response',
+      sample: {
+        leaderboards: [
+          leaderboardSample,
+          {
+            id: 7,
+            internalName: 'time-survived',
+            name: 'Time survived',
+            sortMode: 'asc',
+            unique: true,
+            uniqueByProps: true,
+            refreshInterval: 'daily',
+            createdAt: '2026-08-15T12:50:21.803Z',
+            updatedAt: '2026-08-15T12:52:47.511Z',
+          },
+        ],
+      },
+    },
+    {
+      title: 'Sample request with filter',
+      sample: {
+        url: '/admin/v1/leaderboards?internalName=highscores',
+        query: {
+          internalName: 'highscores',
+        },
+      },
+    },
+  ],
+} satisfies RouteDocs

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -1,12 +1,14 @@
 import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createLeaderboardAdminRoute } from './create.js'
+import { listLeaderboardsAdminRoute } from './list.js'
 
 export function leaderboardAdminRouter(router: Router) {
   adminRouter(
     '/admin/v1/leaderboards',
     ({ route }) => {
       route(createLeaderboardAdminRoute)
+      route(listLeaderboardsAdminRoute)
     },
     { router, docsKey: 'LeaderboardAdminAPI' },
   )

--- a/src/routes/admin/leaderboard/list.ts
+++ b/src/routes/admin/leaderboard/list.ts
@@ -1,0 +1,27 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { listLeaderboardsHandler } from '../../protected/leaderboard/list.js'
+import { listDocs } from './docs.js'
+
+export const listLeaderboardsAdminRoute = adminRoute({
+  method: 'get',
+  docs: listDocs,
+  schema: (z) => ({
+    query: z.object({
+      internalName: z.string().optional().meta({
+        description: 'Filter leaderboards by internal name',
+      }),
+    }),
+  }),
+  middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_LEADERBOARDS])),
+  handler: (ctx) => {
+    const { internalName } = ctx.state.validated.query
+
+    return listLeaderboardsHandler({
+      em: ctx.em,
+      game: ctx.state.game,
+      internalName,
+    })
+  },
+})

--- a/tests/routes/admin/leaderboard/list.test.ts
+++ b/tests/routes/admin/leaderboard/list.test.ts
@@ -1,0 +1,31 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - list', () => {
+  it('should return a list of leaderboards for a key with the read:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const leaderboards = await new LeaderboardFactory([apiKey.game]).many(3)
+    await em.persist(leaderboards).flush()
+
+    const res = await request(app)
+      .get('/admin/v1/leaderboards')
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.leaderboards).toHaveLength(leaderboards.length)
+  })
+
+  it('should return 403 for a key missing the read:leaderboards scope', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const res = await request(app)
+      .get('/admin/v1/leaderboards')
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('read:leaderboards')
+  })
+})


### PR DESCRIPTION
**New admin endpoint**
- Adds a `GET /admin/v1/leaderboards` admin API route to list all leaderboards for a game.
- Supports an optional `internalName` query filter to narrow results.

**Access control**
- The route requires the `read:leaderboards` admin API key scope, and returns 403 for keys lacking it.