### PR TITLE
Add admin leaderboard entries endpoint and shared query schemas

### DIFF
--- a/src/lib/validation/resetModeValidation.ts
+++ b/src/lib/validation/resetModeValidation.ts
@@ -1,6 +1,18 @@
+import { z } from 'zod'
+
 export const resetModes = ['all', 'live', 'dev'] as const
 
 export type ResetMode = (typeof resetModes)[number]
+
+export const resetModeQuerySchema = z.object({
+  mode: z
+    .enum(resetModes, {
+      error: `Mode must be one of: ${resetModes.join(', ')}`,
+    })
+    .optional()
+    .default('all')
+    .meta({ description: 'Which players to reset: all, live or dev' }),
+})
 
 export function translateResetMode(resetMode: ResetMode) {
   switch (resetMode) {

--- a/src/lib/validation/routes/game-stats/listStatsQuerySchema.ts
+++ b/src/lib/validation/routes/game-stats/listStatsQuerySchema.ts
@@ -1,0 +1,14 @@
+import z from 'zod'
+
+export const listStatsQuerySchema = z.object({
+  withMetrics: z
+    .string()
+    .optional()
+    .meta({ description: 'Set to 1 to include metrics for global stats' }),
+  metricsStartDate: z.string().optional().meta({
+    description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+  }),
+  metricsEndDate: z.string().optional().meta({
+    description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+  }),
+})

--- a/src/lib/validation/routes/leaderboards/entriesQuerySchema.ts
+++ b/src/lib/validation/routes/leaderboards/entriesQuerySchema.ts
@@ -1,0 +1,32 @@
+import z from 'zod'
+import { numericStringSchema } from '../../numericStringSchema.js'
+import { pageSchema } from '../../pageSchema.js'
+
+export const entriesQuerySchema = z.object({
+  page: pageSchema.meta({ description: 'The current pagination index (starting at 0)' }),
+  aliasId: numericStringSchema
+    .optional()
+    .meta({ description: 'Only return entries for this alias ID' }),
+  withDeleted: z
+    .enum(['0', '1'])
+    .optional()
+    .transform((val) => val === '1')
+    .meta({ description: 'Include entries that were deleted by a refresh interval' }),
+  propKey: z.string().optional().meta({ description: 'Only return entries with this prop key' }),
+  propValue: z
+    .string()
+    .optional()
+    .meta({ description: 'Only return entries with a matching prop key and value' }),
+  startDate: z.string().optional().meta({
+    description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+  }),
+  endDate: z.string().optional().meta({
+    description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
+  }),
+  aliasService: z.string().optional().meta({
+    description: 'Only return entries for this player alias service (e.g. steam, epic, username)',
+  }),
+  playerId: z.uuid().optional().meta({
+    description: 'Only return entries for this player ID',
+  }),
+})

--- a/src/routes/admin/game-stat/find.ts
+++ b/src/routes/admin/game-stat/find.ts
@@ -1,6 +1,7 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
+import { listStatsQuerySchema } from '../../../lib/validation/routes/game-stats/listStatsQuerySchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { loadStat } from './common.js'
 import { findDocs } from './docs.js'
@@ -13,18 +14,7 @@ export const findStatAdminRoute = adminRoute({
     route: z.object({
       id: numericStringSchema.meta({ description: 'The ID of the stat' }),
     }),
-    query: z.object({
-      withMetrics: z
-        .string()
-        .optional()
-        .meta({ description: 'Set to 1 to include metrics for global stats' }),
-      metricsStartDate: z.string().optional().meta({
-        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
-      }),
-      metricsEndDate: z.string().optional().meta({
-        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
-      }),
-    }),
+    query: listStatsQuerySchema,
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_STATS]), loadStat),
   handler: async (ctx) => {

--- a/src/routes/admin/game-stat/list.ts
+++ b/src/routes/admin/game-stat/list.ts
@@ -1,5 +1,6 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { listStatsQuerySchema } from '../../../lib/validation/routes/game-stats/listStatsQuerySchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { listStatsHandler } from '../../protected/game-stat/list.js'
 import { listDocs } from './docs.js'
@@ -7,19 +8,8 @@ import { listDocs } from './docs.js'
 export const listStatsAdminRoute = adminRoute({
   method: 'get',
   docs: listDocs,
-  schema: (z) => ({
-    query: z.object({
-      withMetrics: z
-        .string()
-        .optional()
-        .meta({ description: 'Set to 1 to include metrics for global stats' }),
-      metricsStartDate: z.string().optional().meta({
-        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
-      }),
-      metricsEndDate: z.string().optional().meta({
-        description: 'A UTC Date (YYYY-MM-DD), DateTime (ISO 8601) or millisecond timestamp',
-      }),
-    }),
+  schema: () => ({
+    query: listStatsQuerySchema,
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.READ_STATS])),
   handler: (ctx) => {

--- a/src/routes/admin/game-stat/reset.ts
+++ b/src/routes/admin/game-stat/reset.ts
@@ -1,7 +1,7 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
-import { resetModes } from '../../../lib/validation/resetModeValidation.js'
+import { resetModeQuerySchema } from '../../../lib/validation/resetModeValidation.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { resetStatHandler } from '../../protected/game-stat/reset.js'
 import { loadStat } from './common.js'
@@ -15,15 +15,7 @@ export const resetStatAdminRoute = adminRoute({
     route: z.object({
       id: numericStringSchema.meta({ description: 'The ID of the stat' }),
     }),
-    query: z.object({
-      mode: z
-        .enum(resetModes, {
-          error: `Mode must be one of: ${resetModes.join(', ')}`,
-        })
-        .optional()
-        .default('all')
-        .meta({ description: 'Which players to reset: all, live or dev' }),
-    }),
+    query: resetModeQuerySchema,
   }),
   middleware: withMiddleware(requireAdminScopes([AdminAPIKeyScope.WRITE_STATS]), loadStat),
   handler: (ctx) => {

--- a/src/routes/admin/leaderboard/common.ts
+++ b/src/routes/admin/leaderboard/common.ts
@@ -1,0 +1,26 @@
+import { Next } from 'koa'
+import Leaderboard from '../../../entities/leaderboard.js'
+import { AdminAPIRouteContext } from '../../../lib/routing/context.js'
+
+type AdminLeaderboardRouteState = {
+  leaderboard: Leaderboard
+}
+
+export async function loadLeaderboard(
+  ctx: AdminAPIRouteContext<AdminLeaderboardRouteState>,
+  next: Next,
+) {
+  const { id } = ctx.params as { id: string }
+
+  const leaderboard = await ctx.em.repo(Leaderboard).findOne({
+    id: Number(id),
+    game: ctx.state.game,
+  })
+
+  if (!leaderboard) {
+    return ctx.throw(404, 'Leaderboard not found')
+  }
+
+  ctx.state.leaderboard = leaderboard
+  await next()
+}

--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -34,6 +34,63 @@ export const createDocs = {
   ],
 } satisfies RouteDocs
 
+const entrySample = {
+  position: 0,
+  id: 4,
+  score: 593.21,
+  leaderboardName: 'Highscore',
+  leaderboardInternalName: 'highscore',
+  leaderboardSortMode: 'asc',
+  playerAlias: {
+    id: 1,
+    service: 'steam',
+    identifier: '11133645',
+    displayName: '11133645',
+    player: {
+      id: '7a4e70ec-6ee6-418e-923d-b3a45051b7f9',
+      props: [],
+      aliases: ['/* [Circular] */'],
+      devBuild: false,
+      createdAt: '2026-08-01T13:20:32.133Z',
+      lastSeenAt: '2026-08-15T15:09:43.066Z',
+    },
+    lastSeenAt: '2026-08-15T15:09:43.066Z',
+    createdAt: '2026-08-01T13:20:32.133Z',
+    updatedAt: '2026-08-01T13:20:32.133Z',
+  },
+  hidden: false,
+  props: [],
+  createdAt: '2026-08-02T14:01:18.727Z',
+  updatedAt: '2026-08-02T14:01:18.727Z',
+  deletedAt: null,
+}
+
+export const entriesDocs = {
+  description: "List a leaderboard's entries\n50 results are returned per page",
+  samples: [
+    {
+      title: 'Sample response',
+      sample: {
+        entries: [entrySample],
+        count: 1,
+        itemsPerPage: 50,
+        isLastPage: true,
+      },
+    },
+    {
+      title: 'Sample request with filters',
+      sample: {
+        url: '/admin/v1/leaderboards/4/entries?page=0&withDeleted=1&propKey=team',
+        query: {
+          page: 0,
+          withDeleted: '1',
+          propKey: 'team',
+        },
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const listDocs = {
   description: 'List all leaderboards',
   samples: [

--- a/src/routes/admin/leaderboard/entries.ts
+++ b/src/routes/admin/leaderboard/entries.ts
@@ -1,23 +1,27 @@
-import { APIKeyScope } from '../../../entities/api-key.js'
-import { apiRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
 import { entriesQuerySchema } from '../../../lib/validation/routes/leaderboards/entriesQuerySchema.js'
-import { requireScopes } from '../../../middleware/policy-middleware.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
 import { listEntriesHandler } from '../../protected/leaderboard/entries.js'
 import { loadLeaderboard } from './common.js'
-import { getDocs } from './docs.js'
+import { entriesDocs } from './docs.js'
 
-export const getRoute = apiRoute({
+export const listEntriesAdminRoute = adminRoute({
   method: 'get',
-  path: '/:internalName/entries',
-  docs: getDocs,
+  path: '/:id/entries',
+  docs: entriesDocs,
   schema: (z) => ({
     route: z.object({
-      internalName: z.string().meta({ description: 'The internal name of the leaderboard' }),
+      id: numericStringSchema.meta({ description: 'The ID of the leaderboard' }),
     }),
     query: entriesQuerySchema,
   }),
-  middleware: withMiddleware(requireScopes([APIKeyScope.READ_LEADERBOARDS]), loadLeaderboard),
-  handler: async (ctx) => {
+  middleware: withMiddleware(
+    requireAdminScopes([AdminAPIKeyScope.READ_LEADERBOARDS]),
+    loadLeaderboard,
+  ),
+  handler: (ctx) => {
     const {
       page,
       aliasId,
@@ -34,7 +38,6 @@ export const getRoute = apiRoute({
       em: ctx.em,
       leaderboard: ctx.state.leaderboard,
       includeDevData: ctx.state.includeDevData,
-      forwarded: true,
       page,
       aliasId,
       withDeleted,

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -1,6 +1,7 @@
 import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createLeaderboardAdminRoute } from './create.js'
+import { listEntriesAdminRoute } from './entries.js'
 import { listLeaderboardsAdminRoute } from './list.js'
 
 export function leaderboardAdminRouter(router: Router) {
@@ -9,6 +10,7 @@ export function leaderboardAdminRouter(router: Router) {
     ({ route }) => {
       route(createLeaderboardAdminRoute)
       route(listLeaderboardsAdminRoute)
+      route(listEntriesAdminRoute)
     },
     { router, docsKey: 'LeaderboardAdminAPI' },
   )

--- a/src/routes/protected/game-feedback/reset-category.ts
+++ b/src/routes/protected/game-feedback/reset-category.ts
@@ -4,7 +4,10 @@ import GameFeedback from '../../../entities/game-feedback.js'
 import { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
-import { resetModes, translateResetMode } from '../../../lib/validation/resetModeValidation.js'
+import {
+  resetModeQuerySchema,
+  translateResetMode,
+} from '../../../lib/validation/resetModeValidation.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadFeedbackCategory } from './common.js'
@@ -12,15 +15,8 @@ import { loadFeedbackCategory } from './common.js'
 export const resetCategoryRoute = protectedRoute({
   method: 'delete',
   path: '/categories/:id/feedback',
-  schema: (z) => ({
-    query: z.object({
-      mode: z
-        .enum(resetModes, {
-          error: `Mode must be one of: ${resetModes.join(', ')}`,
-        })
-        .optional()
-        .default('all'),
-    }),
+  schema: () => ({
+    query: resetModeQuerySchema,
   }),
   middleware: withMiddleware(
     userTypeGate([UserType.ADMIN], 'reset feedback'),

--- a/src/routes/protected/game-stat/list.ts
+++ b/src/routes/protected/game-stat/list.ts
@@ -4,6 +4,7 @@ import type Game from '../../../entities/game.js'
 import GameStat from '../../../entities/game-stat.js'
 import { withResponseCache } from '../../../lib/perf/responseCache.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { listStatsQuerySchema } from '../../../lib/validation/routes/game-stats/listStatsQuerySchema.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 
 export async function listStatsHandler({
@@ -70,12 +71,8 @@ export async function listStatsHandler({
 
 export const listRoute = protectedRoute({
   method: 'get',
-  schema: (z) => ({
-    query: z.object({
-      withMetrics: z.string().optional(),
-      metricsStartDate: z.string().optional(),
-      metricsEndDate: z.string().optional(),
-    }),
+  schema: () => ({
+    query: listStatsQuerySchema,
   }),
   middleware: withMiddleware(loadGame),
   handler: async (ctx) => {

--- a/src/routes/protected/game-stat/reset.ts
+++ b/src/routes/protected/game-stat/reset.ts
@@ -14,7 +14,7 @@ import { streamByCursor } from '../../../lib/perf/streamByCursor.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import {
   ResetMode,
-  resetModes,
+  resetModeQuerySchema,
   translateResetMode,
 } from '../../../lib/validation/resetModeValidation.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
@@ -144,15 +144,8 @@ export async function resetStatHandler({
 export const resetRoute = protectedRoute({
   method: 'delete',
   path: '/:id/player-stats',
-  schema: (z) => ({
-    query: z.object({
-      mode: z
-        .enum(resetModes, {
-          error: `Mode must be one of: ${resetModes.join(', ')}`,
-        })
-        .optional()
-        .default('all'),
-    }),
+  schema: () => ({
+    query: resetModeQuerySchema,
   }),
   middleware: withMiddleware(userTypeGate([UserType.ADMIN], 'reset stats'), loadStat),
   handler: async (ctx) => {

--- a/src/routes/protected/leaderboard/entries.ts
+++ b/src/routes/protected/leaderboard/entries.ts
@@ -8,8 +8,7 @@ import Player from '../../../entities/player.js'
 import { DEFAULT_PAGE_SIZE } from '../../../lib/pagination/itemsPerPage.js'
 import { withResponseCache } from '../../../lib/perf/responseCache.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
-import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
-import { pageSchema } from '../../../lib/validation/pageSchema.js'
+import { entriesQuerySchema } from '../../../lib/validation/routes/leaderboards/entriesQuerySchema.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { loadLeaderboard } from './common.js'
 
@@ -262,21 +261,8 @@ export async function listEntriesHandler({
 export const entriesRoute = protectedRoute({
   method: 'get',
   path: '/:id/entries',
-  schema: (z) => ({
-    query: z.object({
-      page: pageSchema,
-      aliasId: numericStringSchema.optional(),
-      withDeleted: z
-        .enum(['0', '1'])
-        .optional()
-        .transform((val) => val === '1'),
-      propKey: z.string().optional(),
-      propValue: z.string().optional(),
-      startDate: z.string().optional(),
-      endDate: z.string().optional(),
-      aliasService: z.string().optional(),
-      playerId: z.uuid().optional(),
-    }),
+  schema: () => ({
+    query: entriesQuerySchema,
   }),
   middleware: withMiddleware(loadGame, loadLeaderboard()),
   handler: async (ctx) => {

--- a/src/routes/protected/leaderboard/reset.ts
+++ b/src/routes/protected/leaderboard/reset.ts
@@ -5,7 +5,10 @@ import { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
-import { resetModes, translateResetMode } from '../../../lib/validation/resetModeValidation.js'
+import {
+  resetModeQuerySchema,
+  translateResetMode,
+} from '../../../lib/validation/resetModeValidation.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadLeaderboard } from './common.js'
@@ -13,15 +16,8 @@ import { loadLeaderboard } from './common.js'
 export const resetRoute = protectedRoute({
   method: 'delete',
   path: '/:id/entries',
-  schema: (z) => ({
-    query: z.object({
-      mode: z
-        .enum(resetModes, {
-          error: `Mode must be one of: ${resetModes.join(', ')}`,
-        })
-        .optional()
-        .default('all'),
-    }),
+  schema: () => ({
+    query: resetModeQuerySchema,
   }),
   middleware: withMiddleware(
     userTypeGate([UserType.ADMIN], 'reset leaderboard entries'),

--- a/tests/routes/admin/leaderboard/entries.test.ts
+++ b/tests/routes/admin/leaderboard/entries.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - entries', () => {
+  it("should return a leaderboard's entries for a key with the read:leaderboards scope", async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const players = await new PlayerFactory([apiKey.game]).many(5)
+    em.persist(players)
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).withEntries().one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .get(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.entries).toHaveLength(leaderboard.entries.length)
+    expect(res.body.count).toBe(leaderboard.entries.length)
+    expect(res.body.isLastPage).toBe(true)
+  })
+
+  it('should return 404 for a non-existent leaderboard', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const res = await request(app)
+      .get('/admin/v1/leaderboards/21312312/entries')
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+  })
+
+  it('should return 403 for a key missing the read:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_STATS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .get(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('read:leaderboards')
+  })
+})


### PR DESCRIPTION
**Admin leaderboard entries endpoint**
- Adds a new admin API endpoint `GET /admin/v1/leaderboards/:id/entries` that lists a leaderboard's entries, gated behind the `read:leaderboards` admin scope and returning 404 for unknown leaderboards.
- The endpoint reuses the existing entry-listing logic shared with the game API and dashboard routes, and documents the response shape and available filters (page, props, dates, alias, player).

**Shared query schemas**
- Extracts the leaderboard entries query schema, game-stat metrics query schema, and reset-mode query schema into shared validation modules.
- Replaces duplicated inline query definitions across the public API, protected dashboard, and admin routes so all three surface the same validated query parameters.