### PR TITLE
 Add admin leaderboard entry update API

### DIFF
--- a/src/lib/docs/docs-registry.ts
+++ b/src/lib/docs/docs-registry.ts
@@ -1,4 +1,4 @@
-import z from 'zod'
+import { z as zod } from 'zod'
 import type { ValidationSchema } from '../../middleware/validator-middleware.js'
 import { Middleware } from '../routing/router.js'
 import { RouteState } from '../routing/state.js'
@@ -7,8 +7,6 @@ import {
   type ExtractedParam,
   type ExtractedParams,
 } from './schema-introspector.js'
-
-type ZodType = typeof z
 
 export type HttpMethod = 'get' | 'post' | 'put' | 'patch' | 'delete'
 
@@ -87,13 +85,13 @@ export class DocsRegistry {
     key: string
     method: HttpMethod
     path: string
-    schema?: (z: ZodType) => ValidationSchema
+    schema?: (z: typeof zod) => ValidationSchema
     middleware?: Middleware<S>[]
     docs?: RouteDocs
   }) {
     const service = this.services.get(key) ?? this.addService(key, path)
 
-    const params = schema ? extractParamsFromSchema(schema(z)) : undefined
+    const params = schema ? extractParamsFromSchema(schema(zod)) : undefined
 
     service.routes.push({
       method: method,

--- a/src/lib/routing/router.ts
+++ b/src/lib/routing/router.ts
@@ -1,7 +1,7 @@
 import type Koa from 'koa'
 import { SpanStatusCode, trace } from '@opentelemetry/api'
 import Router from 'koa-tree-router'
-import { z } from 'zod'
+import { z as zod } from 'zod'
 import type { ValidationSchema, ValidatedContext } from '../../middleware/validator-middleware.js'
 import type { AppParameterizedContext } from './context.js'
 import { decodeParamsMiddleware } from '../../middleware/decode-params-middleware.js'
@@ -90,8 +90,6 @@ type RouteHelpers<S extends RouteState> = {
   ) => void
 }
 
-type ZodBuilder = typeof z
-
 // used to ensure we only pass in the schema properties
 // while keeping type inference
 type Exact<T, Shape> = {
@@ -106,7 +104,7 @@ export type ValidatedRouteConfig<
   path?: string
   docs?: RouteDocs
   middleware?: Middleware<S>[]
-  schema: (z: ZodBuilder) => V & Exact<V, ValidationSchema>
+  schema: (z: typeof zod) => V & Exact<V, ValidationSchema>
   handler: ValidatedHandler<V, S>
 }
 
@@ -149,7 +147,7 @@ function mountRoute<S extends RouteState, V extends ValidationSchema | undefined
 
   const allMiddleware = ('schema' in config && config.schema
     ? [
-        tracedMiddleware('validate', validate(config.schema(z)) as Middleware<S>),
+        tracedMiddleware('validate', validate(config.schema(zod)) as Middleware<S>),
         ...traced,
         async (ctx: ValidatedContext<V extends ValidationSchema ? V : never, S>) => {
           const response = await tracedHandler(() => {

--- a/src/lib/validation/routes/leaderboards/createLeaderboardBodySchema.ts
+++ b/src/lib/validation/routes/leaderboards/createLeaderboardBodySchema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+import {
+  LeaderboardRefreshInterval,
+  LeaderboardSortMode,
+} from '../../../../entities/leaderboard.js'
+
+const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
+const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
+
+export function createLeaderboardBodySchema(zod: typeof z) {
+  return zod.object({
+    internalName: zod.string().meta({ description: 'The internal name of the leaderboard' }),
+    name: zod.string().meta({ description: 'The display name of the leaderboard' }),
+    sortMode: zod
+      .enum(LeaderboardSortMode, {
+        error: `Sort mode must be one of ${sortModeValues}`,
+      })
+      .meta({ description: 'How entries are sorted: asc or desc' }),
+    unique: zod.boolean().meta({
+      description: 'Whether each player can only have a single entry',
+    }),
+    refreshInterval: zod
+      .enum(LeaderboardRefreshInterval, {
+        error: `Refresh interval must be one of ${refreshIntervalValues}`,
+      })
+      .optional()
+      .meta({
+        description: 'How often the leaderboard resets: never, daily, weekly, monthly or yearly',
+      }),
+    uniqueByProps: zod.boolean().optional().meta({
+      description: 'Whether entries are unique based on their props',
+    }),
+  })
+}

--- a/src/lib/validation/routes/leaderboards/updateLeaderboardEntryBodySchema.ts
+++ b/src/lib/validation/routes/leaderboards/updateLeaderboardEntryBodySchema.ts
@@ -1,0 +1,6 @@
+import z from 'zod'
+
+export const updateLeaderboardEntryBodySchema = z.object({
+  hidden: z.boolean().optional().meta({ description: 'Whether the entry is hidden' }),
+  newScore: z.number().optional().meta({ description: 'The new score for the entry' }),
+})

--- a/src/routes/admin/leaderboard/create.ts
+++ b/src/routes/admin/leaderboard/create.ts
@@ -1,7 +1,7 @@
 import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
 import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { createLeaderboardBodySchema } from '../../../lib/validation/routes/leaderboards/createLeaderboardBodySchema.js'
 import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
-import { createLeaderboardBodySchema } from '../../protected/leaderboard/common.js'
 import { createLeaderboardHandler } from '../../protected/leaderboard/create.js'
 import { createDocs } from './docs.js'
 

--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -91,6 +91,25 @@ export const entriesDocs = {
   ],
 } satisfies RouteDocs
 
+export const updateEntryDocs = {
+  description: 'Update a leaderboard entry',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        newScore: 725.5,
+        hidden: false,
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        entry: entrySample,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const listDocs = {
   description: 'List all leaderboards',
   samples: [

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -3,6 +3,7 @@ import { adminRouter } from '../../../lib/routing/router.js'
 import { createLeaderboardAdminRoute } from './create.js'
 import { listEntriesAdminRoute } from './entries.js'
 import { listLeaderboardsAdminRoute } from './list.js'
+import { updateLeaderboardEntryAdminRoute } from './update-entry.js'
 
 export function leaderboardAdminRouter(router: Router) {
   adminRouter(
@@ -11,6 +12,7 @@ export function leaderboardAdminRouter(router: Router) {
       route(createLeaderboardAdminRoute)
       route(listLeaderboardsAdminRoute)
       route(listEntriesAdminRoute)
+      route(updateLeaderboardEntryAdminRoute)
     },
     { router, docsKey: 'LeaderboardAdminAPI' },
   )

--- a/src/routes/admin/leaderboard/update-entry.ts
+++ b/src/routes/admin/leaderboard/update-entry.ts
@@ -1,0 +1,45 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import LeaderboardEntry from '../../../entities/leaderboard-entry.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
+import { updateLeaderboardEntryBodySchema } from '../../../lib/validation/routes/leaderboards/updateLeaderboardEntryBodySchema.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { updateLeaderboardEntryHandler } from '../../protected/leaderboard/update-entry.js'
+import { loadLeaderboard } from './common.js'
+import { updateEntryDocs } from './docs.js'
+
+export const updateLeaderboardEntryAdminRoute = adminRoute({
+  method: 'patch',
+  path: '/:id/entries/:entryId',
+  docs: updateEntryDocs,
+  schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the leaderboard' }),
+      entryId: numericStringSchema.meta({ description: 'The ID of the leaderboard entry' }),
+    }),
+    body: updateLeaderboardEntryBodySchema,
+  }),
+  middleware: withMiddleware(
+    requireAdminScopes([AdminAPIKeyScope.WRITE_LEADERBOARDS]),
+    loadLeaderboard,
+  ),
+  handler: async (ctx) => {
+    const { entryId } = ctx.state.validated.route
+
+    const entry = await ctx.em.repo(LeaderboardEntry).findOne({
+      id: entryId,
+      leaderboard: ctx.state.leaderboard,
+    })
+
+    if (!entry) {
+      return ctx.throw(404, 'Leaderboard entry not found')
+    }
+
+    return updateLeaderboardEntryHandler({
+      em: ctx.em,
+      entry,
+      body: ctx.state.validated.body,
+      actor: ctx.state.key,
+    })
+  },
+})

--- a/src/routes/protected/game-feedback/toggle-archived.ts
+++ b/src/routes/protected/game-feedback/toggle-archived.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z as zod } from 'zod'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import GameFeedback from '../../../entities/game-feedback.js'
 import { UserType } from '../../../entities/user.js'
@@ -11,9 +11,9 @@ import { loadFeedback } from './common.js'
 
 type FeedbackRouteState = ProtectedRouteState & GameRouteState & { feedback: GameFeedback }
 
-const toggleArchivedSchema = (zod: typeof z) => ({
-  body: zod.object({
-    archived: zod.boolean(),
+const toggleArchivedSchema = (z: typeof zod) => ({
+  body: z.object({
+    archived: z.boolean(),
   }),
 })
 

--- a/src/routes/protected/game-stat/common.ts
+++ b/src/routes/protected/game-stat/common.ts
@@ -1,13 +1,11 @@
 import { Next } from 'koa'
 import assert from 'node:assert'
-import { RefinementCtx, ZodType, z } from 'zod'
+import { RefinementCtx, ZodType, z as zod } from 'zod'
 import GameStat from '../../../entities/game-stat.js'
 import PlayerGameStat from '../../../entities/player-game-stat.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { ProtectedRouteContext } from '../../../lib/routing/context.js'
 import { GameRouteState } from '../../../middleware/game-middleware.js'
-
-type Z = typeof z
 
 type StatSchemaData = {
   maxChange?: number | null
@@ -59,7 +57,7 @@ function validateStatBody(data: StatSchemaData, ctx: RefinementCtx) {
   }
 }
 
-function statFields(z: Z) {
+function statFields(z: typeof zod) {
   return {
     name: z.string().meta({ description: 'The display name of the stat' }),
     global: z
@@ -81,7 +79,7 @@ function statFields(z: Z) {
   }
 }
 
-export function createStatBodySchema(z: Z) {
+export function createStatBodySchema(z: typeof zod) {
   return z
     .object({
       internalName: z.string().meta({ description: 'The internal name of the stat' }),
@@ -99,7 +97,7 @@ function optionalFields(fields: Record<string, ZodType>): Record<string, ZodType
   return result
 }
 
-export function updateStatBodySchema(z: Z) {
+export function updateStatBodySchema(z: typeof zod) {
   return z.object(optionalFields(statFields(z))).superRefine(validateStatBody)
 }
 

--- a/src/routes/protected/leaderboard/common.ts
+++ b/src/routes/protected/leaderboard/common.ts
@@ -1,42 +1,9 @@
 import { Next } from 'koa'
-import { z } from 'zod'
-import Leaderboard, {
-  LeaderboardRefreshInterval,
-  LeaderboardSortMode,
-} from '../../../entities/leaderboard.js'
+import Leaderboard from '../../../entities/leaderboard.js'
 import { ProtectedRouteContext } from '../../../lib/routing/context.js'
 import { GameRouteState } from '../../../middleware/game-middleware.js'
 
 type LeaderboardRouteContext = ProtectedRouteContext<GameRouteState & { leaderboard: Leaderboard }>
-
-const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
-const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
-
-export function createLeaderboardBodySchema(zod: typeof z) {
-  return zod.object({
-    internalName: zod.string().meta({ description: 'The internal name of the leaderboard' }),
-    name: zod.string().meta({ description: 'The display name of the leaderboard' }),
-    sortMode: zod
-      .enum(LeaderboardSortMode, {
-        error: `Sort mode must be one of ${sortModeValues}`,
-      })
-      .meta({ description: 'How entries are sorted: asc or desc' }),
-    unique: zod.boolean().meta({
-      description: 'Whether each player can only have a single entry',
-    }),
-    refreshInterval: zod
-      .enum(LeaderboardRefreshInterval, {
-        error: `Refresh interval must be one of ${refreshIntervalValues}`,
-      })
-      .optional()
-      .meta({
-        description: 'How often the leaderboard resets: never, daily, weekly, monthly or yearly',
-      }),
-    uniqueByProps: zod.boolean().optional().meta({
-      description: 'Whether entries are unique based on their props',
-    }),
-  })
-}
 
 export function loadLeaderboard(withEntries: boolean = false) {
   return async (ctx: LeaderboardRouteContext, next: Next) => {

--- a/src/routes/protected/leaderboard/create.ts
+++ b/src/routes/protected/leaderboard/create.ts
@@ -12,9 +12,9 @@ import { buildErrorResponse } from '../../../lib/errors/buildErrorResponse.js'
 import triggerIntegrations from '../../../lib/integrations/triggerIntegrations.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { createLeaderboardBodySchema } from '../../../lib/validation/routes/leaderboards/createLeaderboardBodySchema.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
-import { createLeaderboardBodySchema } from './common.js'
 
 type CreateLeaderboardParams = {
   em: EntityManager

--- a/src/routes/protected/leaderboard/update-entry.ts
+++ b/src/routes/protected/leaderboard/update-entry.ts
@@ -1,21 +1,95 @@
+import type z from 'zod'
+import { EntityManager } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import LeaderboardEntry from '../../../entities/leaderboard-entry.js'
 import { UserType } from '../../../entities/user.js'
+import User from '../../../entities/user.js'
 import triggerIntegrations from '../../../lib/integrations/triggerIntegrations.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { updateLeaderboardEntryBodySchema } from '../../../lib/validation/routes/leaderboards/updateLeaderboardEntryBodySchema.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadLeaderboard } from './common.js'
 
+export async function updateLeaderboardEntryHandler({
+  em,
+  entry,
+  body,
+  actor,
+}: {
+  em: EntityManager
+  entry: LeaderboardEntry
+  body: z.infer<typeof updateLeaderboardEntryBodySchema>
+  actor: User | AdminAPIKey
+}) {
+  const { hidden, newScore } = body
+
+  if (typeof hidden === 'boolean') {
+    entry.hidden = hidden
+
+    createGameActivity(em, {
+      actor,
+      game: entry.leaderboard.game,
+      type: hidden
+        ? GameActivityType.LEADERBOARD_ENTRY_HIDDEN
+        : GameActivityType.LEADERBOARD_ENTRY_RESTORED,
+      extra: {
+        leaderboardInternalName: entry.leaderboard.internalName,
+        entryId: entry.id,
+        display: {
+          Player: entry.playerAlias.player.id,
+          Score: entry.score,
+        },
+      },
+    })
+
+    await triggerIntegrations(em, entry.leaderboard.game, (integration) => {
+      return integration.handleLeaderboardEntryVisibilityToggled(em, entry)
+    })
+  }
+
+  if (typeof newScore === 'number') {
+    const oldScore = entry.score
+    entry.score = newScore
+
+    createGameActivity(em, {
+      actor,
+      game: entry.leaderboard.game,
+      type: GameActivityType.LEADERBOARD_ENTRY_UPDATED,
+      extra: {
+        leaderboardInternalName: entry.leaderboard.internalName,
+        entryId: entry.id,
+        display: {
+          Player: entry.playerAlias.player.id,
+          Leaderboard: entry.leaderboard.internalName,
+          'Old score': oldScore,
+          'New score': newScore,
+        },
+      },
+    })
+
+    await triggerIntegrations(em, entry.leaderboard.game, (integration) => {
+      return integration.handleLeaderboardEntryCreated(em, entry)
+    })
+  }
+
+  await em.flush()
+
+  return {
+    status: 200,
+    body: {
+      entry,
+    },
+  }
+}
+
 export const updateEntryRoute = protectedRoute({
   method: 'patch',
   path: '/:id/entries/:entryId',
-  schema: (z) => ({
-    body: z.object({
-      hidden: z.boolean().optional(),
-      newScore: z.number().optional(),
-    }),
+  schema: () => ({
+    body: updateLeaderboardEntryBodySchema,
   }),
   middleware: withMiddleware(
     userTypeGate([UserType.ADMIN], 'update leaderboard entries'),
@@ -24,10 +98,8 @@ export const updateEntryRoute = protectedRoute({
   ),
   handler: async (ctx) => {
     const { entryId } = ctx.params as { entryId: string }
-    const { hidden, newScore } = ctx.state.validated.body
-    const em = ctx.em
 
-    const entry = await em.repo(LeaderboardEntry).findOne({
+    const entry = await ctx.em.repo(LeaderboardEntry).findOne({
       id: Number(entryId),
       leaderboard: ctx.state.leaderboard,
     })
@@ -36,62 +108,11 @@ export const updateEntryRoute = protectedRoute({
       return ctx.throw(404, 'Leaderboard entry not found')
     }
 
-    if (typeof hidden === 'boolean') {
-      entry.hidden = hidden
-
-      createGameActivity(em, {
-        actor: ctx.state.user,
-        game: entry.leaderboard.game,
-        type: hidden
-          ? GameActivityType.LEADERBOARD_ENTRY_HIDDEN
-          : GameActivityType.LEADERBOARD_ENTRY_RESTORED,
-        extra: {
-          leaderboardInternalName: entry.leaderboard.internalName,
-          entryId: entry.id,
-          display: {
-            Player: entry.playerAlias.player.id,
-            Score: entry.score,
-          },
-        },
-      })
-
-      await triggerIntegrations(em, entry.leaderboard.game, (integration) => {
-        return integration.handleLeaderboardEntryVisibilityToggled(em, entry)
-      })
-    }
-
-    if (typeof newScore === 'number') {
-      const oldScore = entry.score
-      entry.score = newScore
-
-      createGameActivity(em, {
-        actor: ctx.state.user,
-        game: entry.leaderboard.game,
-        type: GameActivityType.LEADERBOARD_ENTRY_UPDATED,
-        extra: {
-          leaderboardInternalName: entry.leaderboard.internalName,
-          entryId: entry.id,
-          display: {
-            Player: entry.playerAlias.player.id,
-            Leaderboard: entry.leaderboard.internalName,
-            'Old score': oldScore,
-            'New score': newScore,
-          },
-        },
-      })
-
-      await triggerIntegrations(em, entry.leaderboard.game, (integration) => {
-        return integration.handleLeaderboardEntryCreated(em, entry)
-      })
-    }
-
-    await em.flush()
-
-    return {
-      status: 200,
-      body: {
-        entry,
-      },
-    }
+    return updateLeaderboardEntryHandler({
+      em: ctx.em,
+      entry,
+      body: ctx.state.validated.body,
+      actor: ctx.state.user,
+    })
   },
 })

--- a/src/routes/protected/player-group/common.ts
+++ b/src/routes/protected/player-group/common.ts
@@ -1,5 +1,5 @@
 import { Next } from 'koa'
-import { RefinementCtx, z as zodLib } from 'zod'
+import { RefinementCtx, z as zod } from 'zod'
 import PlayerGroupRule, {
   PlayerGroupRuleCastType,
   PlayerGroupRuleName,
@@ -7,8 +7,6 @@ import PlayerGroupRule, {
 import PlayerGroup, { PlayerRuleFields, RuleMode } from '../../../entities/player-group.js'
 import { ProtectedRouteContext } from '../../../lib/routing/context.js'
 import { GameRouteState } from '../../../middleware/game-middleware.js'
-
-type Z = typeof zodLib
 
 type PlayerGroupRouteContext = ProtectedRouteContext<GameRouteState & { group: PlayerGroup }>
 
@@ -55,7 +53,7 @@ function validateRules(rules: RuleInput[], ctx: RefinementCtx) {
   }
 }
 
-const ruleSchema = (z: Z) =>
+const ruleSchema = (z: typeof zod) =>
   z.object({
     name: z.enum(PlayerGroupRuleName),
     field: z.string(),
@@ -64,18 +62,18 @@ const ruleSchema = (z: Z) =>
     castType: z.enum(PlayerGroupRuleCastType),
   })
 
-const rulesAndModeFields = (z: Z) => ({
+const rulesAndModeFields = (z: typeof zod) => ({
   ruleMode: z.enum(RuleMode),
   rules: z.array(ruleSchema(z)),
 })
 
-export function rulesAndModeSchema(z: Z) {
+export function rulesAndModeSchema(z: typeof zod) {
   return z.object(rulesAndModeFields(z)).superRefine((data, ctx) => {
     validateRules(data.rules, ctx)
   })
 }
 
-export function groupBodySchema(z: Z) {
+export function groupBodySchema(z: typeof zod) {
   return z
     .object({
       ...rulesAndModeFields(z),

--- a/tests/routes/admin/leaderboard/update-entry.test.ts
+++ b/tests/routes/admin/leaderboard/update-entry.test.ts
@@ -1,0 +1,121 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import LeaderboardEntryFactory from '../../../fixtures/LeaderboardEntryFactory.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - update entry', () => {
+  it("should update a leaderboard entry's score for a key with the write:leaderboards scope", async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(10)
+    const entry = await new LeaderboardEntryFactory(leaderboard, players)
+      .state(() => ({ score: 100 }))
+      .one()
+    await em.persist(entry).flush()
+
+    const res = await request(app)
+      .patch(`/admin/v1/leaderboards/${leaderboard.id}/entries/${entry.id}`)
+      .send({ newScore: 200 })
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.entry.score).toBe(200)
+
+    const activity = await em.repo(GameActivity).findOne({
+      type: GameActivityType.LEADERBOARD_ENTRY_UPDATED,
+      game: apiKey.game,
+      extra: {
+        leaderboardInternalName: entry.leaderboard.internalName,
+        entryId: entry.id,
+        display: {
+          Player: entry.playerAlias.player.id,
+          Leaderboard: entry.leaderboard.internalName,
+          'Old score': 100,
+          'New score': 200,
+        },
+      },
+    })
+
+    expect(activity).not.toBeNull()
+  })
+
+  it('should mark a leaderboard entry as hidden', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(10)
+    const entry = await new LeaderboardEntryFactory(leaderboard, players).one()
+    await em.persist(entry).flush()
+
+    const res = await request(app)
+      .patch(`/admin/v1/leaderboards/${leaderboard.id}/entries/${entry.id}`)
+      .send({ hidden: true })
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.entry.hidden).toBe(true)
+
+    const activity = await em.repo(GameActivity).findOne({
+      type: GameActivityType.LEADERBOARD_ENTRY_HIDDEN,
+      game: apiKey.game,
+      extra: {
+        leaderboardInternalName: entry.leaderboard.internalName,
+        entryId: entry.id,
+        display: {
+          Player: entry.playerAlias.player.id,
+          Score: entry.score,
+        },
+      },
+    })
+
+    expect(activity).not.toBeNull()
+  })
+
+  it('should return 404 for a non-existent entry', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .patch(`/admin/v1/leaderboards/${leaderboard.id}/entries/12312321`)
+      .send({ hidden: true })
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Leaderboard entry not found' })
+  })
+
+  it('should return 404 for a non-existent leaderboard', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const res = await request(app)
+      .patch('/admin/v1/leaderboards/21312312/entries/1')
+      .send({ hidden: true })
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+  })
+
+  it('should return 403 for a key missing the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(10)
+    const entry = await new LeaderboardEntryFactory(leaderboard, players).one()
+    await em.persist(entry).flush()
+
+    const res = await request(app)
+      .patch(`/admin/v1/leaderboards/${leaderboard.id}/entries/${entry.id}`)
+      .send({ hidden: true })
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:leaderboards')
+  })
+})


### PR DESCRIPTION
**Admin leaderboard endpoints**
- Adds `GET /v1/admin/leaderboards/:id/entries` so admin API keys can list a leaderboard's entries with the same filters as the dashboard (alias, props, deleted, dates, service, player), guarded by the `READ_LEADERBOARDS` scope.
- Adds `PATCH /v1/admin/leaderboards/:id/entries/:entryId` so admin API keys can hide/restore an entry or overwrite its score, guarded by the `WRITE_LEADERBOARDS` scope.

**Shared handlers**
- Extracts `updateLeaderboardEntryHandler` and reuses `listEntriesHandler` so the admin API and the existing dashboard routes run identical logic, including game activity logging and integration triggers.
- The admin routes adopt the same `loadLeaderboard` lookup and 404 guard pattern already used by protected routes, so an admin key can only touch leaderboards in its own game.

**Shared validation schemas**
- Moves leaderboard create, update-entry and entries-query schemas into `src/lib/validation/routes/leaderboards/` so API, protected and admin routes share one definition instead of duplicating inline zod objects.
- The public leaderboard entries endpoint now validates against the same `entriesQuerySchema` as the dashboard and admin endpoints, and a shared `resetModeQuerySchema` covers stat/leaderboard reset modes.

**Zod import cleanup**
- Standardises the zod import alias (`z as zod`) across the docs registry, router and several route files so schema-builder function types are inferred without bespoke local type aliases.