### PR TITLE
Add admin API route for updating leaderboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,9 +36,8 @@ ClickHouse migrations are created manually in `src/migrations/clickhouse/` and r
 
 ## Architecture
 
-### Three-Tier Routing System
+### Four-Tier Routing System
 
-The application uses three distinct routing layers with different authentication:
 
 1. **Protected Routes** (`/` prefix) - Web dashboard endpoints
    - Auth: JWT signed with `JWT_SECRET` (user identity)
@@ -50,10 +49,26 @@ The application uses three distinct routing layers with different authentication
    - Configured in: `src/config/api-routes.ts`
    - Routes in: `src/routes/api/`
 
-3. **Public Routes** (`/public/` prefix) - Unauthenticated endpoints
+3. **Admin API Routes** (`/admin/v1/` prefix) - Dashboard/ops endpoints authenticated by admin API keys
+   - Auth: game-specific admin API keys with scope-based authorization
+   - Configured in: `src/config/admin-api-routes.ts`
+   - Routes in: `src/routes/admin/`
+   - Scopes defined in the `AdminAPIKeyScope` enum in `src/entities/admin-api-key.ts`
+
+4. **Public Routes** (`/public/` prefix) - Unauthenticated endpoints
    - Use cases: Webhooks, health checks, password reset
    - Configured in: `src/config/public-routes.ts`
    - Routes in: `src/routes/public/`
+
+### Admin API Route Pattern
+
+Admin API routes mirror the game-facing API routes and share logic with protected dashboard routes:
+
+- **Extract a shared handler** from the protected route (e.g. `createStatHandler`, `listLeaderboardsHandler`) that both the protected and admin routes call. The handler takes `actor: User | AdminAPIKey`, so the protected route passes `ctx.state.user` and the admin route passes `ctx.state.key`.
+- **Authorization** via `requireAdminScopes([AdminAPIKeyScope.X])` (see `src/middleware/policy-middleware.ts`).
+- **Game scoping** comes free from the admin API key middleware (`ctx.state.game` is the key's game). Resources loaded by id must be scoped to it (404 for cross-game), using a per-tree `common.ts` loader (e.g. `src/routes/admin/game-stat/common.ts`). Resource loaders are duplicated per route tree (protected/api/admin each have their own `loadStat`); only generic middleware lives in `src/middleware/`.
+- **Docs are added as you go**: each feature dir has a `docs.ts` exporting `RouteDocs` constants wired via `docs:` on the route config. Schema params get descriptions via `.meta({ description })` (note: `z.object().partial()` strips meta — re-apply it, see `optionalFields` in `src/routes/protected/game-stat/common.ts`).
+- **Register** the feature router in `src/config/admin-api-routes.ts` with a `[feature]AdminRouter` factory and `docsKey`.
 
 ### Request Flow
 
@@ -63,6 +78,7 @@ Then route-specific middleware:
 
 - **API Routes**: API key extraction → JWT auth → rate limiting → current player resolution → player auth validation → continuity checks
 - **Protected Routes**: JWT auth → user authorization
+- **Admin API Routes**: admin API key extraction → scope checks
 - **Public Routes**: No authentication
 
 Finally, route handlers execute.
@@ -109,6 +125,7 @@ src/
 ├── routes/                  # Route handlers
 │   ├── api/                 # Game-facing API endpoints (/v1/*)
 │   ├── protected/           # Dashboard endpoints (/*)
+│   ├── admin/               # Admin API endpoints (/admin/v1/*)
 │   └── public/              # Unauthenticated endpoints (/public/*)
 ├── middleware/              # Request pipeline processors
 ├── config/                  # Route registration, providers, scheduled tasks
@@ -171,4 +188,5 @@ if (!player) {
 - Migration files: `[Timestamp][PascalCaseDescription].ts`
 - Use lazy loading for entity relationships to avoid circular dependencies
 - API endpoints require scope checks via `requireScopes()` middleware
+- Admin API endpoints require scope checks via `requireAdminScopes()` middleware
 - Protected endpoints require user type checks via `userTypeGate()` or `ownerGate()` middleware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,6 @@ ClickHouse migrations are created manually in `src/migrations/clickhouse/` and r
 
 ### Four-Tier Routing System
 
-
 1. **Protected Routes** (`/` prefix) - Web dashboard endpoints
    - Auth: JWT signed with `JWT_SECRET` (user identity)
    - Configured in: `src/config/protected-routes.ts`

--- a/src/lib/validation/routes/leaderboards/updateLeaderboardBodySchema.ts
+++ b/src/lib/validation/routes/leaderboards/updateLeaderboardBodySchema.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+import {
+  LeaderboardRefreshInterval,
+  LeaderboardSortMode,
+} from '../../../../entities/leaderboard.js'
+
+const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
+const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
+
+export function updateLeaderboardBodySchema(zod: typeof z) {
+  return zod.object({
+    name: zod.string().optional().meta({ description: 'The display name of the leaderboard' }),
+    sortMode: zod
+      .enum(LeaderboardSortMode, {
+        error: `Sort mode must be one of ${sortModeValues}`,
+      })
+      .optional()
+      .meta({ description: 'How entries are sorted: asc or desc' }),
+    unique: zod.boolean().optional().meta({
+      description: 'Whether each player can only have a single entry',
+    }),
+    refreshInterval: zod
+      .enum(LeaderboardRefreshInterval, {
+        error: `Refresh interval must be one of ${refreshIntervalValues}`,
+      })
+      .optional()
+      .meta({
+        description: 'How often the leaderboard resets: never, daily, weekly, monthly or yearly',
+      }),
+    uniqueByProps: zod.boolean().optional().meta({
+      description: 'Whether entries are unique based on their props',
+    }),
+  })
+}

--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -110,6 +110,25 @@ export const updateEntryDocs = {
   ],
 } satisfies RouteDocs
 
+export const updateDocs = {
+  description: 'Update a leaderboard',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        name: 'Highscores',
+        sortMode: 'desc',
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        leaderboard: leaderboardSample,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const listDocs = {
   description: 'List all leaderboards',
   samples: [

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -4,6 +4,7 @@ import { createLeaderboardAdminRoute } from './create.js'
 import { listEntriesAdminRoute } from './entries.js'
 import { listLeaderboardsAdminRoute } from './list.js'
 import { updateLeaderboardEntryAdminRoute } from './update-entry.js'
+import { updateLeaderboardAdminRoute } from './update.js'
 
 export function leaderboardAdminRouter(router: Router) {
   adminRouter(
@@ -12,6 +13,7 @@ export function leaderboardAdminRouter(router: Router) {
       route(createLeaderboardAdminRoute)
       route(listLeaderboardsAdminRoute)
       route(listEntriesAdminRoute)
+      route(updateLeaderboardAdminRoute)
       route(updateLeaderboardEntryAdminRoute)
     },
     { router, docsKey: 'LeaderboardAdminAPI' },

--- a/src/routes/admin/leaderboard/update.ts
+++ b/src/routes/admin/leaderboard/update.ts
@@ -1,0 +1,31 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
+import { updateLeaderboardBodySchema } from '../../../lib/validation/routes/leaderboards/updateLeaderboardBodySchema.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { updateLeaderboardHandler } from '../../protected/leaderboard/update.js'
+import { loadLeaderboard } from './common.js'
+import { updateDocs } from './docs.js'
+
+export const updateLeaderboardAdminRoute = adminRoute({
+  method: 'put',
+  path: '/:id',
+  docs: updateDocs,
+  schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the leaderboard' }),
+    }),
+    body: updateLeaderboardBodySchema(z),
+  }),
+  middleware: withMiddleware(
+    requireAdminScopes([AdminAPIKeyScope.WRITE_LEADERBOARDS]),
+    loadLeaderboard,
+  ),
+  handler: (ctx) =>
+    updateLeaderboardHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard,
+      body: ctx.state.validated.body,
+      actor: ctx.state.key,
+    }),
+})

--- a/src/routes/protected/leaderboard/update.ts
+++ b/src/routes/protected/leaderboard/update.ts
@@ -1,87 +1,88 @@
+import { EntityManager } from '@mikro-orm/mysql'
+import { z } from 'zod'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
-import Leaderboard, {
-  LeaderboardSortMode,
-  LeaderboardRefreshInterval,
-} from '../../../entities/leaderboard.js'
+import Leaderboard, { LeaderboardRefreshInterval } from '../../../entities/leaderboard.js'
+import User from '../../../entities/user.js'
 import updateAllowedKeys from '../../../lib/entities/updateAllowedKeys.js'
 import triggerIntegrations from '../../../lib/integrations/triggerIntegrations.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { updateLeaderboardBodySchema } from '../../../lib/validation/routes/leaderboards/updateLeaderboardBodySchema.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { archiveEntriesForLeaderboard } from '../../../tasks/archiveLeaderboardEntries.js'
 import { loadLeaderboard } from './common.js'
 
-const sortModeValues = Object.values(LeaderboardSortMode).join(', ')
-const refreshIntervalValues = Object.values(LeaderboardRefreshInterval).join(', ')
+export async function updateLeaderboardHandler({
+  em,
+  leaderboard,
+  body,
+  actor,
+}: {
+  em: EntityManager
+  leaderboard: Leaderboard
+  body: z.infer<ReturnType<typeof updateLeaderboardBodySchema>>
+  actor: User | AdminAPIKey
+}) {
+  const [, changedProperties] = updateAllowedKeys(leaderboard, body, [
+    'name',
+    'sortMode',
+    'unique',
+    'refreshInterval',
+    'uniqueByProps',
+  ])
+
+  if (
+    changedProperties.includes('refreshInterval') &&
+    leaderboard.refreshInterval !== LeaderboardRefreshInterval.NEVER
+  ) {
+    await archiveEntriesForLeaderboard(em, leaderboard)
+  }
+
+  await deferClearResponseCache(leaderboard.getEntriesCacheKey(true))
+
+  createGameActivity(em, {
+    actor,
+    game: leaderboard.game,
+    type: GameActivityType.LEADERBOARD_UPDATED,
+    extra: {
+      leaderboardInternalName: leaderboard.internalName,
+      display: {
+        'Updated properties': changedProperties
+          .map((prop) => `${prop}: ${body[prop as keyof typeof body]}`)
+          .join(', '),
+      },
+    },
+  })
+
+  await em.flush()
+
+  await triggerIntegrations(em, leaderboard.game, (integration) => {
+    return integration.handleLeaderboardUpdated(em, leaderboard)
+  })
+
+  return {
+    status: 200,
+    body: {
+      leaderboard,
+    },
+  }
+}
 
 export const updateRoute = protectedRoute({
   method: 'put',
   path: '/:id',
   schema: (z) => ({
-    body: z.object({
-      name: z.string().optional(),
-      sortMode: z
-        .enum(LeaderboardSortMode, {
-          error: `Sort mode must be one of ${sortModeValues}`,
-        })
-        .optional(),
-      unique: z.boolean().optional(),
-      refreshInterval: z
-        .enum(LeaderboardRefreshInterval, {
-          error: `Refresh interval must be one of ${refreshIntervalValues}`,
-        })
-        .optional(),
-      uniqueByProps: z.boolean().optional(),
-    }),
+    body: updateLeaderboardBodySchema(z),
   }),
   middleware: withMiddleware(loadGame, loadLeaderboard()),
   handler: async (ctx) => {
-    const em = ctx.em
-
-    const [leaderboard, changedProperties] = updateAllowedKeys(
-      ctx.state.leaderboard as Leaderboard,
-      ctx.state.validated.body,
-      ['name', 'sortMode', 'unique', 'refreshInterval', 'uniqueByProps'],
-    )
-
-    if (
-      changedProperties.includes('refreshInterval') &&
-      leaderboard.refreshInterval !== LeaderboardRefreshInterval.NEVER
-    ) {
-      await archiveEntriesForLeaderboard(em, leaderboard)
-    }
-
-    await deferClearResponseCache(leaderboard.getEntriesCacheKey(true))
-
-    createGameActivity(em, {
+    return updateLeaderboardHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard as Leaderboard,
+      body: ctx.state.validated.body,
       actor: ctx.state.user,
-      game: leaderboard.game,
-      type: GameActivityType.LEADERBOARD_UPDATED,
-      extra: {
-        leaderboardInternalName: leaderboard.internalName,
-        display: {
-          'Updated properties': changedProperties
-            .map((prop) => {
-              const value = ctx.state.validated.body[prop as keyof typeof ctx.state.validated.body]
-              return `${prop}: ${value}`
-            })
-            .join(', '),
-        },
-      },
     })
-
-    await em.flush()
-
-    await triggerIntegrations(em, leaderboard.game, (integration) => {
-      return integration.handleLeaderboardUpdated(em, leaderboard)
-    })
-
-    return {
-      status: 200,
-      body: {
-        leaderboard,
-      },
-    }
   },
 })

--- a/tests/routes/admin/leaderboard/update.test.ts
+++ b/tests/routes/admin/leaderboard/update.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - update', () => {
+  it('should update a leaderboard for a key with the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .put(`/admin/v1/leaderboards/${leaderboard.id}`)
+      .send({ name: 'The new name' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.leaderboard.name).toBe('The new name')
+
+    const activity = await em.repo(GameActivity).findOne({
+      type: GameActivityType.LEADERBOARD_UPDATED,
+      game: apiKey.game,
+      adminAPIKey: apiKey,
+      extra: {
+        leaderboardInternalName: leaderboard.internalName,
+      },
+    })
+
+    expect(activity).not.toBeNull()
+  })
+
+  it('should return 404 for a non-existent leaderboard', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const res = await request(app)
+      .put('/admin/v1/leaderboards/21312312')
+      .send({ name: 'The new name' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Leaderboard not found' })
+  })
+
+  it('should return 403 for a key missing the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .put(`/admin/v1/leaderboards/${leaderboard.id}`)
+      .send({ name: 'The new name' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:leaderboards')
+  })
+})


### PR DESCRIPTION
**New endpoint**
- Adds `PUT /admin/v1/leaderboards/:id`, letting admin API keys with the `write:leaderboards` scope update a leaderboard's name, sort mode, uniqueness rules, and refresh interval.
- The route loads the leaderboard scoped to the key's game (404 for cross-game or missing boards) and rejects keys lacking the scope with 403.

**Shared handler**
- Extracts the update logic from the protected dashboard route into `updateLeaderboardHandler`, which both the protected and admin routes now call, passing either a `User` or an `AdminAPIKey` as the actor.
- Extracts the leaderboard update body validation into a shared schema used by both routes.

**Consistent behavior**
- The admin route inherits existing behavior: entries are archived when the refresh interval changes, the response cache is cleared, game activity is logged, and integrations are triggered.