### PR TITLE
Add admin API endpoint to reset leaderboard entries

### DIFF
--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -129,6 +129,27 @@ export const updateDocs = {
   ],
 } satisfies RouteDocs
 
+export const resetDocs = {
+  description: 'Reset a leaderboard\u2019s entries\nOptionally filtered to live or dev players',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        url: '/admin/v1/leaderboards/4/entries?mode=dev',
+        query: {
+          mode: 'dev',
+        },
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        deletedCount: 12,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const listDocs = {
   description: 'List all leaderboards',
   samples: [

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -3,6 +3,7 @@ import { adminRouter } from '../../../lib/routing/router.js'
 import { createLeaderboardAdminRoute } from './create.js'
 import { listEntriesAdminRoute } from './entries.js'
 import { listLeaderboardsAdminRoute } from './list.js'
+import { resetLeaderboardAdminRoute } from './reset.js'
 import { updateLeaderboardEntryAdminRoute } from './update-entry.js'
 import { updateLeaderboardAdminRoute } from './update.js'
 
@@ -15,6 +16,7 @@ export function leaderboardAdminRouter(router: Router) {
       route(listEntriesAdminRoute)
       route(updateLeaderboardAdminRoute)
       route(updateLeaderboardEntryAdminRoute)
+      route(resetLeaderboardAdminRoute)
     },
     { router, docsKey: 'LeaderboardAdminAPI' },
   )

--- a/src/routes/admin/leaderboard/reset.ts
+++ b/src/routes/admin/leaderboard/reset.ts
@@ -1,0 +1,31 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
+import { resetModeQuerySchema } from '../../../lib/validation/resetModeValidation.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { resetLeaderboardEntriesHandler } from '../../protected/leaderboard/reset.js'
+import { loadLeaderboard } from './common.js'
+import { resetDocs } from './docs.js'
+
+export const resetLeaderboardAdminRoute = adminRoute({
+  method: 'delete',
+  path: '/:id/entries',
+  docs: resetDocs,
+  schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the leaderboard' }),
+    }),
+    query: resetModeQuerySchema,
+  }),
+  middleware: withMiddleware(
+    requireAdminScopes([AdminAPIKeyScope.WRITE_LEADERBOARDS]),
+    loadLeaderboard,
+  ),
+  handler: (ctx) =>
+    resetLeaderboardEntriesHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard,
+      mode: ctx.state.validated.query.mode,
+      actor: ctx.state.key,
+    }),
+})

--- a/src/routes/protected/leaderboard/reset.ts
+++ b/src/routes/protected/leaderboard/reset.ts
@@ -1,17 +1,75 @@
-import { FilterQuery } from '@mikro-orm/mysql'
+import { EntityManager, FilterQuery } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import LeaderboardEntry from '../../../entities/leaderboard-entry.js'
-import { UserType } from '../../../entities/user.js'
+import Leaderboard from '../../../entities/leaderboard.js'
+import User, { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import {
+  ResetMode,
   resetModeQuerySchema,
   translateResetMode,
 } from '../../../lib/validation/resetModeValidation.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadLeaderboard } from './common.js'
+
+export async function resetLeaderboardEntriesHandler({
+  em,
+  leaderboard,
+  mode,
+  actor,
+}: {
+  em: EntityManager
+  leaderboard: Leaderboard
+  mode: ResetMode
+  actor: User | AdminAPIKey
+}) {
+  const where: FilterQuery<LeaderboardEntry> = { leaderboard }
+
+  if (mode === 'dev') {
+    where.playerAlias = {
+      player: {
+        devBuild: true,
+      },
+    }
+  } else if (mode === 'live') {
+    where.playerAlias = {
+      player: {
+        devBuild: false,
+      },
+    }
+  }
+
+  const deletedCount = await em.transactional(async (trx) => {
+    const count = await trx.repo(LeaderboardEntry).nativeDelete(where)
+    createGameActivity(trx, {
+      actor,
+      game: leaderboard.game,
+      type: GameActivityType.LEADERBOARD_ENTRIES_RESET,
+      extra: {
+        leaderboardInternalName: leaderboard.internalName,
+        display: {
+          'Reset mode': translateResetMode(mode),
+          'Deleted count': count,
+        },
+      },
+    })
+
+    return count
+  })
+
+  await deferClearResponseCache(leaderboard.getEntriesCacheKey(true))
+
+  return {
+    status: 200,
+    body: {
+      deletedCount,
+    },
+  }
+}
 
 export const resetRoute = protectedRoute({
   method: 'delete',
@@ -24,52 +82,11 @@ export const resetRoute = protectedRoute({
     loadGame,
     loadLeaderboard(),
   ),
-  handler: async (ctx) => {
-    const { mode } = ctx.state.validated.query
-    const em = ctx.em
-    const leaderboard = ctx.state.leaderboard
-
-    const where: FilterQuery<LeaderboardEntry> = { leaderboard }
-
-    if (mode === 'dev') {
-      where.playerAlias = {
-        player: {
-          devBuild: true,
-        },
-      }
-    } else if (mode === 'live') {
-      where.playerAlias = {
-        player: {
-          devBuild: false,
-        },
-      }
-    }
-
-    const deletedCount = await em.transactional(async (trx) => {
-      const count = await trx.repo(LeaderboardEntry).nativeDelete(where)
-      createGameActivity(trx, {
-        actor: ctx.state.user,
-        game: leaderboard.game,
-        type: GameActivityType.LEADERBOARD_ENTRIES_RESET,
-        extra: {
-          leaderboardInternalName: leaderboard.internalName,
-          display: {
-            'Reset mode': translateResetMode(mode),
-            'Deleted count': count,
-          },
-        },
-      })
-
-      return count
-    })
-
-    await deferClearResponseCache(leaderboard.getEntriesCacheKey(true))
-
-    return {
-      status: 200,
-      body: {
-        deletedCount,
-      },
-    }
-  },
+  handler: (ctx) =>
+    resetLeaderboardEntriesHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard as Leaderboard,
+      mode: ctx.state.validated.query.mode,
+      actor: ctx.state.user,
+    }),
 })

--- a/tests/routes/admin/leaderboard/reset.test.ts
+++ b/tests/routes/admin/leaderboard/reset.test.ts
@@ -1,0 +1,97 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import LeaderboardEntry from '../../../../src/entities/leaderboard-entry.js'
+import LeaderboardEntryFactory from '../../../fixtures/LeaderboardEntryFactory.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - reset entries', () => {
+  it('should reset all entries for a key with the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(3)
+    await em.persist(entries).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.deletedCount).toBe(3)
+
+    const remainingEntries = await em.repo(LeaderboardEntry).find({ leaderboard })
+    expect(remainingEntries).toHaveLength(0)
+  })
+
+  it('should return 404 for a non-existent leaderboard', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const res = await request(app)
+      .delete('/admin/v1/leaderboards/21312312/entries')
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+  })
+
+  it('should return 400 for an invalid mode', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .query({ mode: 'invalid' })
+      .auth(keyString, { type: 'bearer' })
+      .expect(400)
+
+    expect(res.body).toStrictEqual({
+      errors: {
+        mode: ['Mode must be one of: all, live, dev'],
+      },
+    })
+  })
+
+  it('should return 403 for a key missing the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(2)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(2)
+    await em.persist(entries).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:leaderboards')
+
+    const remainingEntries = await em.repo(LeaderboardEntry).find({ leaderboard })
+    expect(remainingEntries).toHaveLength(2)
+  })
+
+  it('should return 404 for a leaderboard in another game', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+    const { apiKey: otherKey } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([otherKey.game]).one()
+    const players = await new PlayerFactory([otherKey.game]).many(2)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(2)
+    await em.persist(entries).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}/entries`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+
+    const remainingEntries = await em.repo(LeaderboardEntry).find({ leaderboard })
+    expect(remainingEntries).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
**New admin API endpoint**
- Add a DELETE /admin/v1/leaderboards/:id/entries endpoint that deletes a leaderboard's entries, optionally filtered to live or dev players via the ?mode= query parameter.
- The endpoint requires an admin API key with the write:leaderboards scope.

**Shared handler**
- Extract the reset logic from the existing protected dashboard route into a shared handler so both the dashboard and admin API can reuse it, keeping the behavior identical across surfaces.
- The handler records a game activity entry noting the reset mode and deleted count, and clears the leaderboard response cache after the deletion.