### PR TITLE
Add admin API leaderboard delete route

### DIFF
--- a/src/routes/admin/leaderboard/delete.ts
+++ b/src/routes/admin/leaderboard/delete.ts
@@ -1,0 +1,28 @@
+import { AdminAPIKeyScope } from '../../../entities/admin-api-key.js'
+import { adminRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { numericStringSchema } from '../../../lib/validation/numericStringSchema.js'
+import { requireAdminScopes } from '../../../middleware/policy-middleware.js'
+import { deleteLeaderboardHandler } from '../../protected/leaderboard/delete.js'
+import { loadLeaderboard } from './common.js'
+import { deleteDocs } from './docs.js'
+
+export const deleteLeaderboardAdminRoute = adminRoute({
+  method: 'delete',
+  path: '/:id',
+  docs: deleteDocs,
+  schema: (z) => ({
+    route: z.object({
+      id: numericStringSchema.meta({ description: 'The ID of the leaderboard' }),
+    }),
+  }),
+  middleware: withMiddleware(
+    requireAdminScopes([AdminAPIKeyScope.WRITE_LEADERBOARDS]),
+    loadLeaderboard,
+  ),
+  handler: (ctx) =>
+    deleteLeaderboardHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard,
+      actor: ctx.state.key,
+    }),
+})

--- a/src/routes/admin/leaderboard/docs.ts
+++ b/src/routes/admin/leaderboard/docs.ts
@@ -129,6 +129,24 @@ export const updateDocs = {
   ],
 } satisfies RouteDocs
 
+export const deleteDocs = {
+  description: 'Delete a leaderboard',
+  samples: [
+    {
+      title: 'Sample request',
+      sample: {
+        url: '/admin/v1/leaderboards/4',
+      },
+    },
+    {
+      title: 'Sample response',
+      sample: {
+        status: 204,
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const resetDocs = {
   description: 'Reset a leaderboard\u2019s entries\nOptionally filtered to live or dev players',
   samples: [

--- a/src/routes/admin/leaderboard/index.ts
+++ b/src/routes/admin/leaderboard/index.ts
@@ -1,6 +1,7 @@
 import type Router from 'koa-tree-router'
 import { adminRouter } from '../../../lib/routing/router.js'
 import { createLeaderboardAdminRoute } from './create.js'
+import { deleteLeaderboardAdminRoute } from './delete.js'
 import { listEntriesAdminRoute } from './entries.js'
 import { listLeaderboardsAdminRoute } from './list.js'
 import { resetLeaderboardAdminRoute } from './reset.js'
@@ -12,6 +13,7 @@ export function leaderboardAdminRouter(router: Router) {
     '/admin/v1/leaderboards',
     ({ route }) => {
       route(createLeaderboardAdminRoute)
+      route(deleteLeaderboardAdminRoute)
       route(listLeaderboardsAdminRoute)
       route(listEntriesAdminRoute)
       route(updateLeaderboardAdminRoute)

--- a/src/routes/protected/leaderboard/delete.ts
+++ b/src/routes/protected/leaderboard/delete.ts
@@ -1,11 +1,45 @@
+import { EntityManager } from '@mikro-orm/mysql'
+import AdminAPIKey from '../../../entities/admin-api-key.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
-import { UserType } from '../../../entities/user.js'
+import Leaderboard from '../../../entities/leaderboard.js'
+import User, { UserType } from '../../../entities/user.js'
 import triggerIntegrations from '../../../lib/integrations/triggerIntegrations.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 import { loadLeaderboard } from './common.js'
+
+export async function deleteLeaderboardHandler({
+  em,
+  leaderboard,
+  actor,
+}: {
+  em: EntityManager
+  leaderboard: Leaderboard
+  actor: User | AdminAPIKey
+}) {
+  const leaderboardInternalName = leaderboard.internalName
+
+  createGameActivity(em, {
+    actor,
+    game: leaderboard.game,
+    type: GameActivityType.LEADERBOARD_DELETED,
+    extra: {
+      leaderboardInternalName,
+    },
+  })
+
+  await em.remove(leaderboard).flush()
+
+  await triggerIntegrations(em, leaderboard.game, (integration) => {
+    return integration.handleLeaderboardDeleted(em, leaderboardInternalName)
+  })
+
+  return {
+    status: 204,
+  }
+}
 
 export const deleteRoute = protectedRoute({
   method: 'delete',
@@ -15,28 +49,10 @@ export const deleteRoute = protectedRoute({
     loadGame,
     loadLeaderboard(),
   ),
-  handler: async (ctx) => {
-    const em = ctx.em
-    const leaderboard = ctx.state.leaderboard
-    const leaderboardInternalName = leaderboard.internalName
-
-    createGameActivity(em, {
+  handler: (ctx) =>
+    deleteLeaderboardHandler({
+      em: ctx.em,
+      leaderboard: ctx.state.leaderboard,
       actor: ctx.state.user,
-      game: leaderboard.game,
-      type: GameActivityType.LEADERBOARD_DELETED,
-      extra: {
-        leaderboardInternalName,
-      },
-    })
-
-    await em.remove(leaderboard).flush()
-
-    await triggerIntegrations(em, leaderboard.game, (integration) => {
-      return integration.handleLeaderboardDeleted(em, leaderboardInternalName)
-    })
-
-    return {
-      status: 204,
-    }
-  },
+    }),
 })

--- a/tests/routes/admin/leaderboard/delete.test.ts
+++ b/tests/routes/admin/leaderboard/delete.test.ts
@@ -1,0 +1,77 @@
+import request from 'supertest'
+import { AdminAPIKeyScope } from '../../../../src/entities/admin-api-key.js'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import Leaderboard from '../../../../src/entities/leaderboard.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import { createAdminAPIKey } from '../../../utils/createAdminAPIKey.js'
+
+describe('Leaderboard admin API - delete', () => {
+  it('should delete a leaderboard for a key with the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(204)
+
+    expect(res.body).toStrictEqual({})
+
+    const deleted = await em.repo(Leaderboard).find({ id: leaderboard.id })
+    expect(deleted).toHaveLength(0)
+
+    const activity = await em.repo(GameActivity).findOne({
+      type: GameActivityType.LEADERBOARD_DELETED,
+      game: apiKey.game,
+    })
+    expect(activity?.extra.leaderboardInternalName).toBe(leaderboard.internalName)
+  })
+
+  it('should return 404 for a non-existent leaderboard', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const res = await request(app)
+      .delete('/admin/v1/leaderboards/21312312')
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+  })
+
+  it('should return 403 for a key missing the write:leaderboards scope', async () => {
+    const { apiKey, keyString } = await createAdminAPIKey([AdminAPIKeyScope.READ_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(403)
+
+    expect(res.body.message).toContain('write:leaderboards')
+
+    const remaining = await em.repo(Leaderboard).find({ id: leaderboard.id })
+    expect(remaining).toHaveLength(1)
+  })
+
+  it('should return 404 for a leaderboard in another game', async () => {
+    const { keyString } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+    const { apiKey: otherKey } = await createAdminAPIKey([AdminAPIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([otherKey.game]).one()
+    await em.persist(leaderboard).flush()
+
+    const res = await request(app)
+      .delete(`/admin/v1/leaderboards/${leaderboard.id}`)
+      .auth(keyString, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body.message).toBe('Leaderboard not found')
+
+    const remaining = await em.repo(Leaderboard).find({ id: leaderboard.id })
+    expect(remaining).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
**Admin API endpoint**
- Add `DELETE /admin/v1/leaderboards/:id` so leaderboards can be deleted via the admin API, matching the existing dashboard delete flow.
- The endpoint requires the `write:leaderboards` admin scope and returns 204 on success, or 404 for missing or out-of-game leaderboards.

**Shared handler**
- Extract the delete logic from the protected dashboard route into a shared `deleteLeaderboardHandler` that both the protected and admin routes call.
- Game-activity logging and integration triggers behave identically no matter which route performs the delete.