### PR TITLE
Multi-organisation users

### DIFF
--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -21,6 +21,7 @@ import Invite from './invite.js'
 import LeaderboardEntryProp from './leaderboard-entry-prop.js'
 import LeaderboardEntry from './leaderboard-entry.js'
 import Leaderboard from './leaderboard.js'
+import OrganisationMember from './organisation-member.js'
 import OrganisationPricingPlan from './organisation-pricing-plan.js'
 import Organisation from './organisation.js'
 import PlayerAliasSubscription from './player-alias-subscription.js'
@@ -72,6 +73,7 @@ export const entities = [
   SteamworksLeaderboardMapping,
   SteamworksIntegrationEvent,
   Integration,
+  OrganisationMember,
   OrganisationPricingPlan,
   PricingPlan,
   Invite,

--- a/src/entities/organisation-member.ts
+++ b/src/entities/organisation-member.ts
@@ -1,0 +1,37 @@
+import { Entity, Enum, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/es'
+import Organisation from './organisation.js'
+import User, { UserType } from './user.js'
+
+@Entity()
+@Unique({ properties: ['user', 'organisation'] })
+export default class OrganisationMember {
+  @PrimaryKey()
+  id!: number
+
+  @ManyToOne(() => User, { eager: true })
+  user!: User
+
+  @ManyToOne(() => Organisation, { eager: true })
+  organisation!: Organisation
+
+  @Enum(() => UserType)
+  type: UserType = UserType.DEV
+
+  @Property()
+  createdAt: Date = new Date()
+
+  constructor(user: User, organisation: Organisation, type: UserType) {
+    this.user = user
+    this.organisation = organisation
+    this.type = type
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      organisation: this.organisation,
+      type: this.type,
+      createdAt: this.createdAt,
+    }
+  }
+}

--- a/src/entities/user-pinned-group.ts
+++ b/src/entities/user-pinned-group.ts
@@ -18,7 +18,7 @@ export default class UserPinnedGroup {
   createdAt: Date = new Date()
 
   static getCacheKeyForUser(user: User) {
-    return `pinned-group-${user.id}`
+    return `pinned-group-${user.organisation.id}:${user.id}`
   }
 
   constructor(user: User, group: PlayerGroup) {

--- a/src/entities/user.ts
+++ b/src/entities/user.ts
@@ -8,6 +8,7 @@ import {
   Property,
 } from '@mikro-orm/decorators/es'
 import { Collection } from '@mikro-orm/mysql'
+import OrganisationMember from './organisation-member.js'
 import Organisation from './organisation.js'
 import UserRecoveryCode from './user-recovery-code.js'
 import UserTwoFactorAuth from './user-two-factor-auth.js'
@@ -34,6 +35,9 @@ export default class User {
 
   @ManyToOne(() => Organisation, { eager: true })
   organisation!: Organisation
+
+  @OneToMany(() => OrganisationMember, (member) => member.user, { orphanRemoval: true })
+  memberships = new Collection<OrganisationMember>(this)
 
   @Enum(() => UserType)
   type: UserType = UserType.DEV
@@ -64,6 +68,7 @@ export default class User {
       lastSeenAt: this.lastSeenAt,
       emailConfirmed: this.emailConfirmed,
       organisation: this.organisation,
+      memberships: this.memberships.toJSON(),
       type: this.type,
       has2fa: this.twoFactorAuth?.enabled ?? false,
       createdAt: this.createdAt,

--- a/src/lib/auth/getUserFromToken.ts
+++ b/src/lib/auth/getUserFromToken.ts
@@ -5,7 +5,7 @@ export async function getUserFromToken(ctx: ProtectedRouteContext) {
   const em = ctx.em
   const userId = ctx.state.jwt.sub
   const user = await em.repo(User).findOneOrFail(userId, {
-    populate: ['organisation.games'],
+    populate: ['organisation.games', 'memberships.organisation'],
   })
 
   return user

--- a/src/migrations/20260826120000CreateOrganisationMemberTable.ts
+++ b/src/migrations/20260826120000CreateOrganisationMemberTable.ts
@@ -1,0 +1,31 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class CreateOrganisationMemberTable extends Migration {
+  override up(): void | Promise<void> {
+    this.addSql(
+      'create table `organisation_member` (`id` int unsigned not null auto_increment primary key, `user_id` int unsigned not null, `organisation_id` int unsigned not null, `type` tinyint not null, `created_at` datetime not null) default character set utf8mb4 engine = InnoDB;',
+    )
+    this.addSql(
+      'alter table `organisation_member` add index `organisation_member_user_id_index`(`user_id`);',
+    )
+    this.addSql(
+      'alter table `organisation_member` add index `organisation_member_organisation_id_index`(`organisation_id`);',
+    )
+    this.addSql(
+      'alter table `organisation_member` add unique `organisation_member_user_id_organisation_id_unique`(`user_id`, `organisation_id`);',
+    )
+    this.addSql(
+      'alter table `organisation_member` add constraint `organisation_member_user_id_foreign` foreign key (`user_id`) references `user` (`id`) on delete cascade;',
+    )
+    this.addSql(
+      'alter table `organisation_member` add constraint `organisation_member_organisation_id_foreign` foreign key (`organisation_id`) references `organisation` (`id`) on delete cascade;',
+    )
+    this.addSql(
+      'insert into `organisation_member` (`user_id`, `organisation_id`, `type`, `created_at`) select `id`, `organisation_id`, `type`, `created_at` from `user`;',
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql('drop table if exists `organisation_member`;')
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -77,6 +77,7 @@ import { AddGameDisplayNamePropKeyColumn } from './20260615220055AddGameDisplayN
 import { AddGameLogoUrlColumn } from './20260618133542AddGameLogoUrlColumn.js'
 import { CreateDeletedPlayerTable } from './20260626204938CreateDeletedPlayerTable.js'
 import { CreateAdminAPIKeysTable } from './20260711094253CreateAdminAPIKeysTable.js'
+import { CreateOrganisationMemberTable } from './20260826120000CreateOrganisationMemberTable.js'
 
 export default [
   {
@@ -394,5 +395,9 @@ export default [
   {
     name: 'CreateAdminAPIKeysTable',
     class: CreateAdminAPIKeysTable,
+  },
+  {
+    name: 'CreateOrganisationMemberTable',
+    class: CreateOrganisationMemberTable,
   },
 ]

--- a/src/routes/protected/invite/accept.ts
+++ b/src/routes/protected/invite/accept.ts
@@ -1,0 +1,56 @@
+import { GameActivityType } from '../../../entities/game-activity.js'
+import Invite from '../../../entities/invite.js'
+import OrganisationMember from '../../../entities/organisation-member.js'
+import createGameActivity from '../../../lib/logging/createGameActivity.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireEmailConfirmed } from '../../../middleware/policy-middleware.js'
+
+export const acceptInviteRoute = protectedRoute({
+  method: 'post',
+  path: '/join',
+  schema: (z) => ({
+    body: z.object({
+      token: z.string().min(1),
+    }),
+  }),
+  middleware: withMiddleware(requireEmailConfirmed('join organisations')),
+  handler: async (ctx) => {
+    const { token } = ctx.state.validated.body
+    const em = ctx.em
+    const user = ctx.state.user
+
+    const invite = await em.repo(Invite).findOne({ token }, { populate: ['organisation'] })
+    if (!invite || invite.email !== user.email) {
+      return ctx.throw(404, 'Invite not found')
+    }
+
+    const existingMembership = await em.repo(OrganisationMember).findOne({
+      user,
+      organisation: invite.organisation,
+    })
+    if (existingMembership) {
+      await em.remove(invite).flush()
+      return {
+        status: 200,
+        body: {
+          user,
+        },
+      }
+    }
+
+    user.organisation = invite.organisation
+    user.type = invite.type
+    user.memberships.add(new OrganisationMember(user, invite.organisation, invite.type))
+
+    createGameActivity(em, { actor: user, type: GameActivityType.INVITE_ACCEPTED })
+
+    await em.remove(invite).flush()
+
+    return {
+      status: 200,
+      body: {
+        user,
+      },
+    }
+  },
+})

--- a/src/routes/protected/invite/create.ts
+++ b/src/routes/protected/invite/create.ts
@@ -3,7 +3,6 @@ import JoinOrganisation from '../../../emails/join-organisation-mail.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import Invite from '../../../entities/invite.js'
 import { UserType } from '../../../entities/user.js'
-import User from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import queueEmail from '../../../lib/messaging/queueEmail.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
@@ -29,23 +28,16 @@ export const createRoute = protectedRoute({
 
     const inviter = ctx.state.user
 
-    const duplicateEmailUser = await em.repo(User).findOne({ email: email.toLowerCase() })
-    if (duplicateEmailUser) {
-      return ctx.throw(400, 'This email address is already in use')
-    }
-
-    const duplicateEmailInvite = await em.repo(Invite).findOne({ email: email.toLowerCase() })
+    const duplicateEmailInvite = await em.repo(Invite).findOne({
+      email: email.toLowerCase(),
+      organisation: inviter.organisation,
+    })
     if (duplicateEmailInvite) {
-      return ctx.throw(
-        400,
-        duplicateEmailInvite.organisation.id === inviter.organisation.id
-          ? 'An invite for this email address already exists'
-          : 'This email address is already in use',
-      )
+      return ctx.throw(400, 'An invite for this email address already exists')
     }
 
     const invite = new Invite(inviter.organisation)
-    invite.email = email
+    invite.email = email.toLowerCase()
     invite.type = type
     invite.invitedByUser = inviter
 

--- a/src/routes/protected/organisation/change-member-type.ts
+++ b/src/routes/protected/organisation/change-member-type.ts
@@ -1,5 +1,5 @@
+import OrganisationMember from '../../../entities/organisation-member.js'
 import { UserType } from '../../../entities/user.js'
-import User from '../../../entities/user.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { ownerGate, requireEmailConfirmed } from '../../../middleware/policy-middleware.js'
 
@@ -30,13 +30,19 @@ export const changeMemberTypeRoute = protectedRoute({
       return ctx.throw(403, 'You cannot change your own user type')
     }
 
-    const target = await em.repo(User).findOne({ id: userId, organisation: caller.organisation })
-    if (!target) {
+    const membership = await em
+      .repo(OrganisationMember)
+      .findOne({ user: userId, organisation: caller.organisation }, { populate: ['user'] })
+    if (!membership) {
       return ctx.throw(404, 'User not found')
     }
+    const target = membership.user
 
-    target.type = type
-    await em.persist(target).flush()
+    membership.type = type
+    if (target.organisation.id === caller.organisation.id) {
+      target.type = type
+    }
+    await em.persist([membership, target]).flush()
 
     return {
       status: 200,

--- a/src/routes/protected/organisation/current.ts
+++ b/src/routes/protected/organisation/current.ts
@@ -1,7 +1,8 @@
 import Game from '../../../entities/game.js'
 import Invite from '../../../entities/invite.js'
+import OrganisationMember from '../../../entities/organisation-member.js'
 import Player from '../../../entities/player.js'
-import User, { UserType } from '../../../entities/user.js'
+import { UserType } from '../../../entities/user.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
 
@@ -21,7 +22,9 @@ export const currentRoute = protectedRoute({
       playerCountMap.set(game.id, playerCount)
     }
 
-    const members = await em.repo(User).find({ organisation })
+    const memberships = await em
+      .repo(OrganisationMember)
+      .find({ organisation }, { populate: ['user'] })
     const pendingInvites = await em.repo(Invite).find({ organisation })
 
     return {
@@ -31,7 +34,7 @@ export const currentRoute = protectedRoute({
           ...game.toJSON(),
           playerCount: playerCountMap.get(game.id),
         })),
-        members,
+        members: memberships.map(({ user, type }) => ({ ...user.toJSON(), type })),
         pendingInvites,
       },
     }

--- a/src/routes/protected/organisation/index.ts
+++ b/src/routes/protected/organisation/index.ts
@@ -1,14 +1,20 @@
 import type Router from 'koa-tree-router'
 import { protectedRouter } from '../../../lib/routing/router.js'
+import { acceptInviteRoute } from '../invite/accept.js'
 import { changeMemberTypeRoute } from './change-member-type.js'
 import { currentRoute } from './current.js'
+import { listMembershipsRoute } from './list-memberships.js'
 import { removeMemberRoute } from './remove-member.js'
+import { switchOrganisationRoute } from './switch.js'
 
 export function organisationRouter(router: Router) {
   protectedRouter(
     '/organisations',
     ({ route }) => {
       route(currentRoute)
+      route(listMembershipsRoute)
+      route(switchOrganisationRoute)
+      route(acceptInviteRoute)
       route(removeMemberRoute)
       route(changeMemberTypeRoute)
     },

--- a/src/routes/protected/organisation/list-memberships.ts
+++ b/src/routes/protected/organisation/list-memberships.ts
@@ -1,0 +1,19 @@
+import OrganisationMember from '../../../entities/organisation-member.js'
+import { protectedRoute } from '../../../lib/routing/router.js'
+
+export const listMembershipsRoute = protectedRoute({
+  method: 'get',
+  path: '/memberships',
+  handler: async (ctx) => {
+    const memberships = await ctx.em.repo(OrganisationMember).find({
+      user: ctx.state.user,
+    })
+
+    return {
+      status: 200,
+      body: {
+        memberships,
+      },
+    }
+  },
+})

--- a/src/routes/protected/organisation/remove-member.ts
+++ b/src/routes/protected/organisation/remove-member.ts
@@ -2,9 +2,10 @@ import { getGlobalQueue } from '../../../config/global-queues.js'
 import MemberRemovedMail from '../../../emails/member-removed-mail.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import Invite from '../../../entities/invite.js'
+import OrganisationMember from '../../../entities/organisation-member.js'
 import UserPinnedGroup from '../../../entities/user-pinned-group.js'
 import UserSession from '../../../entities/user-session.js'
-import User, { UserType } from '../../../entities/user.js'
+import { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import queueEmail from '../../../lib/messaging/queueEmail.js'
 import { deferClearResponseCache } from '../../../lib/perf/responseCacheQueue.js'
@@ -33,18 +34,35 @@ export const removeMemberRoute = protectedRoute({
       return ctx.throw(403, 'You cannot remove yourself from your organisation')
     }
 
-    const target = await em.repo(User).findOne({ id: userId, organisation: caller.organisation })
-    if (!target) {
+    const membership = await em
+      .repo(OrganisationMember)
+      .findOne({ user: userId, organisation: caller.organisation }, { populate: ['user'] })
+    if (!membership) {
       return ctx.throw(404, 'User not found')
     }
+    const target = membership.user
 
     await em.transactional(async (trx) => {
-      target.organisation = await createOrganisationForUser(trx, target.username, target.email)
-      target.type = UserType.OWNER
+      await trx.nativeDelete(OrganisationMember, { id: membership.id })
+
+      if (target.organisation.id === caller.organisation.id) {
+        const remaining = await trx.repo(OrganisationMember).findOne({ user: target })
+        if (remaining) {
+          target.organisation = remaining.organisation
+          target.type = remaining.type
+        } else {
+          target.organisation = await createOrganisationForUser(trx, target.username, target.email)
+          target.type = UserType.OWNER
+          target.memberships.add(
+            new OrganisationMember(target, target.organisation, UserType.OWNER),
+          )
+        }
+      }
 
       await trx.nativeDelete(UserSession, { user: target })
       await trx.nativeDelete(UserPinnedGroup, { user: target })
       await trx.nativeDelete(Invite, { invitedByUser: target, organisation: caller.organisation })
+      await trx.nativeDelete(Invite, { email: target.email, organisation: caller.organisation })
 
       createGameActivity(trx, {
         actor: caller,

--- a/src/routes/protected/organisation/switch.ts
+++ b/src/routes/protected/organisation/switch.ts
@@ -1,0 +1,38 @@
+import OrganisationMember from '../../../entities/organisation-member.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { requireEmailConfirmed } from '../../../middleware/policy-middleware.js'
+
+export const switchOrganisationRoute = protectedRoute({
+  method: 'post',
+  path: '/switch',
+  schema: (z) => ({
+    body: z.object({
+      organisationId: z.number().int().positive(),
+    }),
+  }),
+  middleware: withMiddleware(requireEmailConfirmed('switch organisations')),
+  handler: async (ctx) => {
+    const { organisationId } = ctx.state.validated.body
+    const em = ctx.em
+    const user = ctx.state.user
+
+    const membership = await em.repo(OrganisationMember).findOne({
+      user,
+      organisation: organisationId,
+    })
+    if (!membership) {
+      return ctx.throw(404, 'Membership not found')
+    }
+
+    user.organisation = membership.organisation
+    user.type = membership.type
+    await em.persist(user).flush()
+
+    return {
+      status: 200,
+      body: {
+        user,
+      },
+    }
+  },
+})

--- a/src/routes/public/user-public/login.ts
+++ b/src/routes/public/user-public/login.ts
@@ -19,7 +19,9 @@ export const loginRoute = publicRoute({
     const em = ctx.em
     const redis = ctx.redis
 
-    const user = await em.repo(User).findOne({ email }, { populate: ['organisation.games'] })
+    const user = await em
+      .repo(User)
+      .findOne({ email }, { populate: ['organisation.games', 'memberships.organisation'] })
     if (!user) {
       return {
         status: 401,

--- a/src/routes/public/user-public/refresh.ts
+++ b/src/routes/public/user-public/refresh.ts
@@ -17,7 +17,7 @@ export const refreshRoute = publicRoute({
         userAgent,
       },
       {
-        populate: ['user.organisation.games'],
+        populate: ['user.organisation.games', 'user.memberships.organisation'],
       },
     )
 

--- a/src/routes/public/user-public/register.ts
+++ b/src/routes/public/user-public/register.ts
@@ -7,6 +7,7 @@ import { getGlobalQueue } from '../../../config/global-queues.js'
 import ConfirmEmail from '../../../emails/confirm-email-mail.js'
 import { GameActivityType } from '../../../entities/game-activity.js'
 import Invite from '../../../entities/invite.js'
+import OrganisationMember from '../../../entities/organisation-member.js'
 import Organisation from '../../../entities/organisation.js'
 import UserAccessCode from '../../../entities/user-access-code.js'
 import User, { UserType } from '../../../entities/user.js'
@@ -109,7 +110,7 @@ export const registerRoute = publicRoute({
         },
       )
 
-      if (!invite || invite.email !== email) {
+      if (!invite || invite.email !== email.toLowerCase()) {
         return {
           status: 404,
           body: { message: 'Invite not found' },
@@ -118,6 +119,7 @@ export const registerRoute = publicRoute({
 
       user.organisation = invite.organisation
       user.type = invite.type
+      user.memberships.add(new OrganisationMember(user, invite.organisation, invite.type))
       user.emailConfirmed = true
 
       createGameActivity(em, { actor: user, type: GameActivityType.INVITE_ACCEPTED })
@@ -127,6 +129,7 @@ export const registerRoute = publicRoute({
       assert(organisationName)
       user.organisation = await createOrganisationForUser(em, organisationName, email)
       user.type = UserType.OWNER
+      user.memberships.add(new OrganisationMember(user, user.organisation, user.type))
     }
 
     await em.persist(user).flush()

--- a/src/routes/public/user-public/use-recovery-code.ts
+++ b/src/routes/public/user-public/use-recovery-code.ts
@@ -19,7 +19,7 @@ export const useRecoveryCodeRoute = publicRoute({
     const redis = ctx.redis
 
     const user = await em.repo(User).findOneOrFail(userId, {
-      populate: ['recoveryCodes', 'organisation.games'],
+      populate: ['recoveryCodes', 'organisation.games', 'memberships.organisation'],
     })
 
     const hasSession = (await redis.get(`2fa:${user.id}`)) === 'true'

--- a/src/routes/public/user-public/verify-2fa.ts
+++ b/src/routes/public/user-public/verify-2fa.ts
@@ -18,7 +18,9 @@ export const verify2faRoute = publicRoute({
     const em = ctx.em
     const redis = ctx.redis
 
-    const user = await em.repo(User).findOneOrFail(userId, { populate: ['organisation.games'] })
+    const user = await em.repo(User).findOneOrFail(userId, {
+      populate: ['organisation.games', 'memberships.organisation'],
+    })
 
     const hasSession = (await redis.get(`2fa:${user.id}`)) === 'true'
 

--- a/src/tasks/deleteInactivePlayers.ts
+++ b/src/tasks/deleteInactivePlayers.ts
@@ -4,9 +4,10 @@ import { subDays } from 'date-fns'
 import { getMikroORM } from '../config/mikro-orm.config.js'
 import { GameActivityType } from '../entities/game-activity.js'
 import Game from '../entities/game.js'
+import OrganisationMember from '../entities/organisation-member.js'
 import { PlayerToDelete } from '../entities/player-to-delete.js'
 import Player from '../entities/player.js'
-import User, { UserType } from '../entities/user.js'
+import { UserType } from '../entities/user.js'
 import createGameActivity from '../lib/logging/createGameActivity.js'
 import { streamByCursor } from '../lib/perf/streamByCursor.js'
 
@@ -43,11 +44,15 @@ async function createPurgeActivity({
   devBuild: boolean
   count: number
 }) {
+  const owner = await em
+    .repo(OrganisationMember)
+    .findOneOrFail(
+      { type: UserType.OWNER, organisation: game.organisation },
+      { populate: ['user'] },
+    )
+
   createGameActivity(em, {
-    actor: await em.repo(User).findOneOrFail({
-      type: UserType.OWNER,
-      organisation: game.organisation,
-    }),
+    actor: owner.user,
     game,
     type: devBuild
       ? GameActivityType.INACTIVE_DEV_PLAYERS_DELETED

--- a/tests/fixtures/UserFactory.ts
+++ b/tests/fixtures/UserFactory.ts
@@ -2,6 +2,7 @@ import { Collection } from '@mikro-orm/mysql'
 import { randEmail, randUserName, randWord } from '@ngneat/falso'
 import bcrypt from 'bcrypt'
 import { Factory } from 'hefty'
+import OrganisationMember from '../../src/entities/organisation-member.js'
 import UserRecoveryCode from '../../src/entities/user-recovery-code.js'
 import UserTwoFactorAuth from '../../src/entities/user-two-factor-auth.js'
 import User, { UserType } from '../../src/entities/user.js'
@@ -21,6 +22,12 @@ export default class UserFactory extends Factory<User> {
       organisation: await new OrganisationFactory().one(),
       type: UserType.DEV,
     }))
+  }
+
+  override async one() {
+    const user = await super.one()
+    user.memberships.add(new OrganisationMember(user, user.organisation, user.type))
+    return user
   }
 
   emailConfirmed(): this {

--- a/tests/routes/protected/invite/create.test.ts
+++ b/tests/routes/protected/invite/create.test.ts
@@ -84,9 +84,9 @@ describe('Invite - create', () => {
     }
   })
 
-  it('should not create an invite when an invite exists for the same email on another organisation', async () => {
+  it('should create an invite when an invite exists for the same email on another organisation', async () => {
     const [otherOrg] = await createOrganisationAndGame()
-    const [token] = await createUserAndToken({ type: UserType.ADMIN, emailConfirmed: true })
+    const [token, user] = await createUserAndToken({ type: UserType.ADMIN, emailConfirmed: true })
 
     const invite = await new InviteFactory()
       .construct(otherOrg)
@@ -98,12 +98,12 @@ describe('Invite - create', () => {
       .post('/invites')
       .send({ email: invite.email, type: UserType.ADMIN })
       .auth(token, { type: 'bearer' })
-      .expect(400)
+      .expect(200)
 
-    expect(res.body).toStrictEqual({ message: 'This email address is already in use' })
+    expect(res.body.invite.organisation.id).toBe(user.organisation.id)
   })
 
-  it('should not create an invite when a user exists for the same email', async () => {
+  it('should create an invite when a user exists for the same email', async () => {
     const [token] = await createUserAndToken({ type: UserType.ADMIN, emailConfirmed: true })
 
     const user = await new UserFactory().state(() => ({ email: randEmail() })).one()
@@ -113,9 +113,9 @@ describe('Invite - create', () => {
       .post('/invites')
       .send({ email: user.email, type: UserType.ADMIN })
       .auth(token, { type: 'bearer' })
-      .expect(400)
+      .expect(200)
 
-    expect(res.body).toStrictEqual({ message: 'This email address is already in use' })
+    expect(res.body.invite.email).toBe(user.email)
   })
 
   it("should not create an invite if the user's email is not confirmed", async () => {

--- a/tests/routes/protected/organisation/join.test.ts
+++ b/tests/routes/protected/organisation/join.test.ts
@@ -1,0 +1,119 @@
+import request from 'supertest'
+import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
+import Invite from '../../../../src/entities/invite.js'
+import OrganisationMember from '../../../../src/entities/organisation-member.js'
+import { UserType } from '../../../../src/entities/user.js'
+import InviteFactory from '../../../fixtures/InviteFactory.js'
+import { clearEntities } from '../../../utils/clearEntities.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Organisation - join via invite', () => {
+  beforeEach(async () => {
+    await clearEntities([GameActivity, Invite])
+  })
+
+  it('should add the user to the organisation and make it their current organisation', async () => {
+    const [token, user] = await createUserAndToken({ emailConfirmed: true })
+    const [organisation] = await createOrganisationAndGame()
+
+    const invite = await new InviteFactory()
+      .construct(organisation)
+      .state(() => ({ email: user.email, type: UserType.ADMIN }))
+      .one()
+    await em.persist(invite).flush()
+
+    const res = await request(app)
+      .post('/organisations/join')
+      .send({ token: invite.token })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.user.organisation.id).toBe(organisation.id)
+    expect(res.body.user.type).toBe(UserType.ADMIN)
+
+    const membership = await em.repo(OrganisationMember).findOneOrFail({
+      user,
+      organisation,
+    })
+    expect(membership.type).toBe(UserType.ADMIN)
+
+    const remainingInvites = await em.repo(Invite).count({ token: invite.token })
+    expect(remainingInvites).toBe(0)
+
+    const activity = await em.repo(GameActivity).findOneOrFail({
+      type: GameActivityType.INVITE_ACCEPTED,
+    })
+    expect(activity.user?.id).toBe(user.id)
+  })
+
+  it('should allow a user to be a member of multiple organisations', async () => {
+    const [token, user] = await createUserAndToken({ emailConfirmed: true })
+    const [secondOrg] = await createOrganisationAndGame()
+
+    const invite = await new InviteFactory()
+      .construct(secondOrg)
+      .state(() => ({ email: user.email }))
+      .one()
+    await em.persist(invite).flush()
+
+    await request(app)
+      .post('/organisations/join')
+      .send({ token: invite.token })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    const memberships = await em.repo(OrganisationMember).find({ user })
+    expect(memberships).toHaveLength(2)
+    expect(memberships.map((member) => member.organisation.id)).toContain(secondOrg.id)
+    expect(memberships.map((member) => member.organisation.id)).toContain(user.organisation.id)
+  })
+
+  it('should consume the invite if the user is already a member', async () => {
+    const [organisation] = await createOrganisationAndGame()
+    const [token, user] = await createUserAndToken({ emailConfirmed: true }, organisation)
+
+    const invite = await new InviteFactory()
+      .construct(organisation)
+      .state(() => ({ email: user.email }))
+      .one()
+    await em.persist(invite).flush()
+
+    await request(app)
+      .post('/organisations/join')
+      .send({ token: invite.token })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    const remainingInvites = await em.repo(Invite).count({ token: invite.token })
+    expect(remainingInvites).toBe(0)
+  })
+
+  it('should return 404 when the invite email does not match the user', async () => {
+    const [token] = await createUserAndToken({ emailConfirmed: true })
+    const [organisation] = await createOrganisationAndGame()
+
+    const invite = await new InviteFactory().construct(organisation).one()
+    await em.persist(invite).flush()
+
+    const res = await request(app)
+      .post('/organisations/join')
+      .send({ token: invite.token })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Invite not found' })
+  })
+
+  it('should return 404 for a missing invite', async () => {
+    const [token] = await createUserAndToken({ emailConfirmed: true })
+
+    const res = await request(app)
+      .post('/organisations/join')
+      .send({ token: 'abc123' })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Invite not found' })
+  })
+})

--- a/tests/routes/protected/organisation/list-memberships.test.ts
+++ b/tests/routes/protected/organisation/list-memberships.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest'
+import OrganisationMember from '../../../../src/entities/organisation-member.js'
+import { UserType } from '../../../../src/entities/user.js'
+import OrganisationFactory from '../../../fixtures/OrganisationFactory.js'
+import OrganisationPricingPlanFactory from '../../../fixtures/OrganisationPricingPlanFactory.js'
+import PricingPlanFactory from '../../../fixtures/PricingPlanFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Organisation - list memberships', () => {
+  it('should return all of the users organisations', async () => {
+    const [organisation] = await createOrganisationAndGame()
+    const [token, user] = await createUserAndToken(
+      { type: UserType.OWNER, emailConfirmed: true },
+      organisation,
+    )
+
+    const pricingPlan = await new PricingPlanFactory().one()
+    const secondOrganisation = await new OrganisationFactory().one()
+    secondOrganisation.pricingPlan = await new OrganisationPricingPlanFactory()
+      .state(() => ({ organisation: secondOrganisation, pricingPlan }))
+      .one()
+    await em.persist(secondOrganisation).flush()
+
+    const membership = new OrganisationMember(user, secondOrganisation, UserType.DEV)
+    await em.persist(membership).flush()
+
+    const res = await request(app)
+      .get('/organisations/memberships')
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.memberships).toHaveLength(2)
+    expect(
+      res.body.memberships.map(
+        (member: { organisation: { id: number } }) => member.organisation.id,
+      ),
+    ).toContain(organisation.id)
+    expect(
+      res.body.memberships.map(
+        (member: { organisation: { id: number } }) => member.organisation.id,
+      ),
+    ).toContain(secondOrganisation.id)
+  })
+})

--- a/tests/routes/protected/organisation/switch.test.ts
+++ b/tests/routes/protected/organisation/switch.test.ts
@@ -1,0 +1,60 @@
+import request from 'supertest'
+import OrganisationMember from '../../../../src/entities/organisation-member.js'
+import { UserType } from '../../../../src/entities/user.js'
+import OrganisationFactory from '../../../fixtures/OrganisationFactory.js'
+import OrganisationPricingPlanFactory from '../../../fixtures/OrganisationPricingPlanFactory.js'
+import PricingPlanFactory from '../../../fixtures/PricingPlanFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Organisation - switch', () => {
+  it('should switch the current organisation and sync the user type', async () => {
+    const [organisation] = await createOrganisationAndGame()
+    const [token, user] = await createUserAndToken(
+      { type: UserType.OWNER, emailConfirmed: true },
+      organisation,
+    )
+
+    const pricingPlan = await new PricingPlanFactory().one()
+    const secondOrganisation = await new OrganisationFactory().one()
+    secondOrganisation.pricingPlan = await new OrganisationPricingPlanFactory()
+      .state(() => ({ organisation: secondOrganisation, pricingPlan }))
+      .one()
+    await em.persist(secondOrganisation).flush()
+
+    const membership = new OrganisationMember(user, secondOrganisation, UserType.DEV)
+    await em.persist(membership).flush()
+
+    const res = await request(app)
+      .post('/organisations/switch')
+      .send({ organisationId: secondOrganisation.id })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.user.organisation.id).toBe(secondOrganisation.id)
+    expect(res.body.user.type).toBe(UserType.DEV)
+  })
+
+  it('should return 404 for an organisation the user is not a member of', async () => {
+    const [token] = await createUserAndToken({ emailConfirmed: true })
+    const [otherOrganisation] = await createOrganisationAndGame()
+
+    const res = await request(app)
+      .post('/organisations/switch')
+      .send({ organisationId: otherOrganisation.id })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+
+    expect(res.body).toStrictEqual({ message: 'Membership not found' })
+  })
+
+  it('should return 400 for an invalid organisation id', async () => {
+    const [token] = await createUserAndToken({ emailConfirmed: true })
+
+    await request(app)
+      .post('/organisations/switch')
+      .send({ organisationId: 'abc' })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+})

--- a/tests/utils/createUserAndToken.ts
+++ b/tests/utils/createUserAndToken.ts
@@ -1,3 +1,4 @@
+import OrganisationMember from '../../src/entities/organisation-member.js'
 import Organisation from '../../src/entities/organisation.js'
 import User from '../../src/entities/user.js'
 import { genAccessToken } from '../../src/lib/auth/buildTokenPair.js'
@@ -13,6 +14,8 @@ export default async function createUserAndToken(
     .one()
   if (organisation) {
     user.organisation = organisation
+    user.memberships.removeAll()
+    user.memberships.add(new OrganisationMember(user, organisation, user.type))
   }
 
   await em.persist(user).flush()


### PR DESCRIPTION
**Multi-organisation memberships**
- Users can now belong to multiple organisations through a new `OrganisationMember` entity, backfilled from existing users by migration.
- Invites are scoped per organisation, so the same email can be invited by several organisations instead of being blocked after the first.
- New endpoints let users list their memberships and switch their active organisation.

**Organisation administration**
- Member type changes and removals now operate on memberships rather than assuming a single home organisation.
- Removing a member reassigns them to another organisation they belong to, or creates a fresh one for them when none remain.
- Removing a member also clears invites sent to that email.

**Identity and session changes**
- User responses and tokens now carry membership data so clients can render an organisation switcher.
- Pinned-group cache keys include the organisation to avoid collisions across organisations.