### PR TITLE
Add event funnels

### DIFF
--- a/src/config/protected-routes.ts
+++ b/src/config/protected-routes.ts
@@ -9,6 +9,7 @@ import { apiKeyRouter } from '../routes/protected/api-key/index.js'
 import { billingRouter } from '../routes/protected/billing/index.js'
 import { chartRouter } from '../routes/protected/chart/index.js'
 import { dataExportRouter } from '../routes/protected/data-export/index.js'
+import { eventFunnelRouter } from '../routes/protected/event-funnel/index.js'
 import { eventRouter } from '../routes/protected/event/index.js'
 import { gameActivityRouter } from '../routes/protected/game-activity/index.js'
 import { gameChannelRouter } from '../routes/protected/game-channel/index.js'
@@ -37,6 +38,7 @@ export function configureProtectedRoutes(app: Koa) {
   chartRouter(router)
   dataExportRouter(router)
   eventRouter(router)
+  eventFunnelRouter(router)
   gameActivityRouter(router)
   gameChannelRouter(router)
   gameFeedbackRouter(router)

--- a/src/entities/event-funnel.ts
+++ b/src/entities/event-funnel.ts
@@ -1,0 +1,74 @@
+import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/es'
+import Game from './game.js'
+
+export const EventFunnelPropOps = [
+  'set',
+  '=',
+  '!=',
+  '>',
+  '>=',
+  '<',
+  '<=',
+  'between',
+  'contains',
+] as const
+
+export type EventFunnelPropOp = (typeof EventFunnelPropOps)[number]
+
+export type EventFunnelPropRule = {
+  key: string
+  op: EventFunnelPropOp
+  value: string[]
+}
+
+export type EventFunnelStepProps = {
+  ruleMode: 'and' | 'or'
+  rules: EventFunnelPropRule[]
+}
+
+export type EventFunnelStep = {
+  name: string
+  props: EventFunnelStepProps
+}
+
+@Entity()
+export default class EventFunnel {
+  @PrimaryKey()
+  id!: number
+
+  @Property()
+  name!: string
+
+  @Property({ type: 'json' })
+  steps: EventFunnelStep[] = []
+
+  @Property()
+  maxGap!: number
+
+  @ManyToOne(() => Game)
+  game: Game
+
+  @Property()
+  createdAt: Date = new Date()
+
+  @Property({ onUpdate: () => new Date() })
+  updatedAt: Date = new Date()
+
+  constructor(game: Game) {
+    this.game = game
+  }
+
+  static getCacheKey(game: Game, funnelId: number) {
+    return `event-funnel-${game.id}-${funnelId}`
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      name: this.name,
+      steps: this.steps,
+      maxGap: this.maxGap,
+      updatedAt: this.updatedAt,
+    }
+  }
+}

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -2,6 +2,7 @@ import AdminAPIKey from './admin-api-key.js'
 import APIKey from './api-key.js'
 import DataExport from './data-export.js'
 import DeletedPlayer from './deleted-player.js'
+import EventFunnel from './event-funnel.js'
 import FailedJob from './failed-job.js'
 import GameActivity from './game-activity.js'
 import GameCenterIntegrationEvent from './game-center-integration-event.js'
@@ -47,6 +48,7 @@ import UserTwoFactorAuth from './user-two-factor-auth.js'
 import User from './user.js'
 
 export const entities = [
+  EventFunnel,
   AdminAPIKey,
   DeletedPlayer,
   GameVerificationKey,

--- a/src/migrations/20260902191008CreateEventFunnelsTable.ts
+++ b/src/migrations/20260902191008CreateEventFunnelsTable.ts
@@ -1,0 +1,22 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class CreateEventFunnelsTable extends Migration {
+  override name = 'CreateEventFunnelsTable'
+
+  override up(): void | Promise<void> {
+    this.addSql(
+      `create table \`event_funnel\` (\`id\` int unsigned not null auto_increment primary key, \`name\` varchar(255) not null, \`steps\` json not null, \`max_gap\` int not null, \`game_id\` int unsigned not null, \`created_at\` datetime not null, \`updated_at\` datetime not null) default character set utf8mb4 engine = InnoDB;`,
+    )
+    this.addSql(
+      `alter table \`event_funnel\` add index \`event_funnel_game_id_index\` (\`game_id\`);`,
+    )
+
+    this.addSql(
+      `alter table \`event_funnel\` add constraint \`event_funnel_game_id_foreign\` foreign key (\`game_id\`) references \`game\` (\`id\`);`,
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`drop table if exists \`event_funnel\`;`)
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -79,6 +79,7 @@ import { CreateDeletedPlayerTable } from './20260626204938CreateDeletedPlayerTab
 import { CreateAdminAPIKeysTable } from './20260711094253CreateAdminAPIKeysTable.js'
 import { AddOrganisationAndUserDeletedAtColumns } from './20260830202536AddOrganisationAndUserDeletedAtColumns.js'
 import { AddPlayersToDeleteUniqueConstraint } from './20260831000000AddPlayersToDeleteUniqueConstraint.js'
+import { CreateEventFunnelsTable } from './20260902191008CreateEventFunnelsTable.js'
 
 export default [
   {
@@ -404,5 +405,9 @@ export default [
   {
     name: 'AddPlayersToDeleteUniqueConstraint',
     class: AddPlayersToDeleteUniqueConstraint,
+  },
+  {
+    name: 'CreateEventFunnelsTable',
+    class: CreateEventFunnelsTable,
   },
 ]

--- a/src/routes/protected/event-funnel/common.ts
+++ b/src/routes/protected/event-funnel/common.ts
@@ -1,0 +1,280 @@
+import type { ClickHouseClient } from '@clickhouse/client'
+import type { Next } from 'koa'
+import { endOfDay } from 'date-fns'
+import { z } from 'zod'
+import type Game from '../../../entities/game.js'
+import EventFunnel, {
+  EventFunnelPropOps,
+  EventFunnelPropRule,
+  EventFunnelStep,
+  EventFunnelStepProps,
+} from '../../../entities/event-funnel.js'
+import { formatDateForClickHouse } from '../../../lib/clickhouse/formatDateTime.js'
+import { ProtectedRouteContext } from '../../../lib/routing/context.js'
+import { dateRangeSchema } from '../../../lib/validation/dateRangeSchema.js'
+import { GameRouteState } from '../../../middleware/game-middleware.js'
+
+export const FUNNEL_CACHE_TTL = 900
+
+export type FunnelResultStep = {
+  eventName: string
+  players: number
+  percentage: number
+  avgSecondsToNext: number | null
+}
+
+type FunnelRow = {
+  id: string
+  t: string
+  delta_ms?: string
+}
+
+type BuildStepQueryArgs = {
+  steps: EventFunnelStep[]
+  maxGap: number
+  game: Game
+  includeDevData: boolean
+  startDate: string
+  endDate: string
+}
+
+type FunnelRouteContext = ProtectedRouteContext<GameRouteState & { funnel: EventFunnel }>
+
+const propRuleSchema = z
+  .object({
+    key: z.string(),
+    op: z.enum(EventFunnelPropOps),
+    value: z.array(z.string()),
+  })
+  .superRefine((rule, ctx) => {
+    const expected = rule.op === 'set' ? 0 : rule.op === 'between' ? 2 : 1
+    if (rule.value.length !== expected) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `op '${rule.op}' expects ${expected} value(s)`,
+        path: ['value'],
+      })
+    }
+  })
+
+const stepSchema = z.object({
+  name: z.string(),
+  props: z.object({
+    ruleMode: z.enum(['and', 'or']),
+    rules: z.array(propRuleSchema).max(10),
+  }),
+})
+
+const stepsSchema = z
+  .array(stepSchema)
+  .min(2)
+  .max(5)
+  .superRefine((steps, ctx) => {
+    const names = steps.map((step) => step.name)
+    if (new Set(names).size !== names.length) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Step names must be distinct',
+      })
+    }
+  })
+
+const funnelContentSchema = z.object({
+  steps: stepsSchema,
+  maxGap: z.number().positive().int(),
+})
+
+export const funnelSchema = z.object({
+  name: z.string().min(1).max(255),
+  steps: stepsSchema,
+  maxGap: z.number().positive().int(),
+})
+
+export const previewSchema = dateRangeSchema.and(funnelContentSchema)
+
+export const updateFunnelSchema = z.object({
+  name: z.string().min(1).max(255).optional(),
+  steps: stepsSchema.optional(),
+  maxGap: z.number().positive().int().optional(),
+})
+
+export async function loadFunnel(ctx: FunnelRouteContext, next: Next) {
+  const { id } = ctx.params as { id: string }
+  const em = ctx.em
+
+  const funnel = await em.repo(EventFunnel).findOne({ id: Number(id), game: ctx.state.game })
+
+  if (!funnel) {
+    return ctx.throw(404, 'Funnel not found')
+  }
+
+  ctx.state.funnel = funnel
+  await next()
+}
+
+function buildRuleClause(
+  rule: EventFunnelPropRule,
+  prefix: string,
+  params: Record<string, unknown>,
+) {
+  switch (rule.op) {
+    case 'set':
+      return '1'
+    case '=': {
+      const v0 = `${prefix}v0`
+      params[v0] = rule.value[0]
+      return `(prop_value = {${v0}:String} OR (isNotNull(toFloat64OrNull(prop_value)) AND toFloat64OrNull(prop_value) = toFloat64OrNull({${v0}:String})))`
+    }
+    case '!=': {
+      const v0 = `${prefix}v0`
+      params[v0] = rule.value[0]
+      return `(prop_value <> {${v0}:String} AND (isNull(toFloat64OrNull(prop_value)) OR toFloat64OrNull(prop_value) <> toFloat64OrNull({${v0}:String})))`
+    }
+    case '>':
+    case '>=':
+    case '<':
+    case '<=': {
+      const v0 = `${prefix}v0`
+      params[v0] = rule.value[0]
+      return `toFloat64OrNull(prop_value) ${rule.op} toFloat64OrNull({${v0}:String})`
+    }
+    case 'between': {
+      const v0 = `${prefix}v0`
+      const v1 = `${prefix}v1`
+      params[v0] = rule.value[0]
+      params[v1] = rule.value[1]
+      return `toFloat64OrNull(prop_value) BETWEEN toFloat64OrNull({${v0}:String}) AND toFloat64OrNull({${v1}:String})`
+    }
+    case 'contains': {
+      const v0 = `${prefix}v0`
+      params[v0] = rule.value[0]
+      return `position(prop_value, {${v0}:String}) > 0`
+    }
+  }
+}
+
+function buildPropsHaving(
+  props: EventFunnelStepProps,
+  prefix: string,
+  params: Record<string, unknown>,
+) {
+  const conditions = props.rules.map((rule, idx) => {
+    const rulePrefix = `${prefix}${idx}_`
+    const keyParam = `${rulePrefix}key`
+    params[keyParam] = rule.key
+    return `countIf(prop_key = {${keyParam}:String} AND ${buildRuleClause(rule, rulePrefix, params)}) > 0`
+  })
+
+  return conditions.join(props.ruleMode === 'and' ? ' AND ' : ' OR ')
+}
+
+function buildStepQuery(stepIdx: number, args: BuildStepQueryArgs) {
+  const { steps, maxGap, game, includeDevData, startDate, endDate } = args
+  const step = steps[stepIdx]
+  const prefix = `s${stepIdx}`
+  const params: Record<string, unknown> = {}
+
+  let sql = `
+    SELECT e.player_alias_id AS id, MIN(e.created_at) AS t
+    ${stepIdx > 0 ? ', toUnixTimestamp64Milli(MIN(e.created_at)) - toUnixTimestamp64Milli(any(p.t)) AS delta_ms' : ''}
+    FROM events e
+  `
+
+  if (stepIdx > 0) {
+    const prev = buildStepQuery(stepIdx - 1, args)
+    Object.assign(params, prev.params)
+    sql += `
+      INNER JOIN (${prev.sql}) p ON p.id = e.player_alias_id
+    `
+  }
+
+  params[`${prefix}_name`] = step.name
+  params.startDate = startDate
+  params.endDate = endDate
+  sql += `
+    WHERE e.game_id = ${game.id}
+      AND e.name = {${prefix}_name:String}
+      AND e.created_at BETWEEN {startDate:String} AND {endDate:String}
+      ${includeDevData ? '' : 'AND e.dev_build = false'}
+  `
+
+  if (stepIdx > 0) {
+    params.maxGap = maxGap
+    sql += `
+      AND e.created_at > p.t
+      AND e.created_at <= p.t + toIntervalSecond({maxGap:Int32})
+    `
+  }
+
+  if (step.props.rules.length > 0) {
+    sql += `
+      AND e.id IN (
+        SELECT event_id
+        FROM event_props
+        WHERE game_id = ${game.id}
+          AND created_at BETWEEN {startDate:String} AND {endDate:String}
+        GROUP BY event_id
+        HAVING ${buildPropsHaving(step.props, `${prefix}_p_`, params)}
+      )
+    `
+  }
+
+  sql += `
+    GROUP BY e.player_alias_id
+  `
+
+  return { sql, params }
+}
+
+export async function computeFunnel({
+  clickhouse,
+  game,
+  includeDevData,
+  steps,
+  maxGap,
+  startDate,
+  endDate,
+}: BuildStepQueryArgs & { clickhouse: ClickHouseClient }): Promise<FunnelResultStep[]> {
+  const args: BuildStepQueryArgs = {
+    steps,
+    maxGap,
+    game,
+    includeDevData,
+    startDate: formatDateForClickHouse(new Date(startDate)),
+    endDate: formatDateForClickHouse(endOfDay(new Date(endDate))),
+  }
+
+  const counts: number[] = []
+  const deltas: number[][] = []
+
+  for (let i = 0; i < steps.length; i++) {
+    const { sql, params } = buildStepQuery(i, args)
+    const rows = await clickhouse
+      .query({ query: sql, query_params: params, format: 'JSONEachRow' })
+      .then((res) => res.json<FunnelRow>())
+
+    counts.push(rows.length)
+    if (i > 0) {
+      deltas.push(
+        rows.filter((row) => row.delta_ms !== undefined).map((row) => Number(row.delta_ms)),
+      )
+    }
+  }
+
+  const firstCount = counts[0]
+
+  return counts.map((count, i) => {
+    const nextDeltas = deltas[i]
+    const avgSecondsToNext =
+      i < steps.length - 1 && nextDeltas.length > 0
+        ? nextDeltas.reduce((sum, delta) => sum + delta, 0) / nextDeltas.length / 1000
+        : null
+
+    return {
+      eventName: steps[i].name,
+      players: count,
+      percentage: firstCount === 0 ? 0 : Math.round((count / firstCount) * 10_000) / 100,
+      avgSecondsToNext,
+    }
+  })
+}

--- a/src/routes/protected/event-funnel/create.ts
+++ b/src/routes/protected/event-funnel/create.ts
@@ -1,0 +1,30 @@
+import EventFunnel from '../../../entities/event-funnel.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { funnelSchema } from './common.js'
+
+export const createRoute = protectedRoute({
+  method: 'post',
+  schema: () => ({
+    body: funnelSchema,
+  }),
+  middleware: withMiddleware(loadGame),
+  handler: async (ctx) => {
+    const body = ctx.state.validated.body
+    const em = ctx.em
+
+    const funnel = new EventFunnel(ctx.state.game)
+    funnel.name = body.name
+    funnel.steps = body.steps
+    funnel.maxGap = body.maxGap
+
+    await em.persist(funnel).flush()
+
+    return {
+      status: 200,
+      body: {
+        funnel,
+      },
+    }
+  },
+})

--- a/src/routes/protected/event-funnel/delete.ts
+++ b/src/routes/protected/event-funnel/delete.ts
@@ -1,0 +1,18 @@
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { loadFunnel } from './common.js'
+
+export const deleteRoute = protectedRoute({
+  method: 'delete',
+  path: '/:id',
+  middleware: withMiddleware(loadGame, loadFunnel),
+  handler: async (ctx) => {
+    const funnel = ctx.state.funnel
+
+    await ctx.em.remove(funnel).flush()
+
+    return {
+      status: 204,
+    }
+  },
+})

--- a/src/routes/protected/event-funnel/get.ts
+++ b/src/routes/protected/event-funnel/get.ts
@@ -1,0 +1,50 @@
+import { withResponseCache } from '../../../lib/perf/responseCache.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { dateRangeSchema } from '../../../lib/validation/dateRangeSchema.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { computeFunnel, FUNNEL_CACHE_TTL, loadFunnel } from './common.js'
+
+export const getRoute = protectedRoute({
+  method: 'get',
+  path: '/:id',
+  schema: () => ({
+    query: dateRangeSchema,
+  }),
+  middleware: withMiddleware(loadGame, loadFunnel),
+  handler: async (ctx) => {
+    const { startDate, endDate } = ctx.state.validated.query
+    const funnel = ctx.state.funnel
+
+    const game = ctx.state.game
+    const includeDevData = ctx.state.includeDevData
+
+    return withResponseCache(
+      {
+        key: `event-funnel-${game.id}-${funnel.id}-${startDate}-${endDate}-${includeDevData ? 'dev' : 'no-dev'}`,
+        ttl: FUNNEL_CACHE_TTL,
+      },
+      async () => {
+        const result = await computeFunnel({
+          clickhouse: ctx.clickhouse,
+          game,
+          includeDevData,
+          steps: funnel.steps,
+          maxGap: funnel.maxGap,
+          startDate,
+          endDate,
+        })
+
+        return {
+          status: 200,
+          body: {
+            funnel,
+            result: {
+              steps: result,
+              lastUpdatedAt: Date.now(),
+            },
+          },
+        }
+      },
+    )
+  },
+})

--- a/src/routes/protected/event-funnel/index.ts
+++ b/src/routes/protected/event-funnel/index.ts
@@ -1,0 +1,25 @@
+import type Router from 'koa-tree-router'
+import { protectedRouter } from '../../../lib/routing/router.js'
+import { createRoute } from './create.js'
+import { deleteRoute } from './delete.js'
+import { getRoute } from './get.js'
+import { listRoute } from './list.js'
+import { previewRoute } from './preview.js'
+import { refreshRoute } from './refresh.js'
+import { updateRoute } from './update.js'
+
+export function eventFunnelRouter(router: Router) {
+  protectedRouter(
+    '/games/:gameId/event-funnels',
+    ({ route }) => {
+      route(previewRoute)
+      route(createRoute)
+      route(listRoute)
+      route(getRoute)
+      route(updateRoute)
+      route(deleteRoute)
+      route(refreshRoute)
+    },
+    { router },
+  )
+}

--- a/src/routes/protected/event-funnel/list.ts
+++ b/src/routes/protected/event-funnel/list.ts
@@ -1,0 +1,20 @@
+import EventFunnel from '../../../entities/event-funnel.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+
+export const listRoute = protectedRoute({
+  method: 'get',
+  middleware: withMiddleware(loadGame),
+  handler: async (ctx) => {
+    const funnels = await ctx.em
+      .repo(EventFunnel)
+      .find({ game: ctx.state.game }, { orderBy: { createdAt: 'desc' } })
+
+    return {
+      status: 200,
+      body: {
+        funnels,
+      },
+    }
+  },
+})

--- a/src/routes/protected/event-funnel/preview.ts
+++ b/src/routes/protected/event-funnel/preview.ts
@@ -1,0 +1,35 @@
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { computeFunnel, previewSchema } from './common.js'
+
+export const previewRoute = protectedRoute({
+  method: 'post',
+  path: '/preview',
+  schema: () => ({
+    body: previewSchema,
+  }),
+  middleware: withMiddleware(loadGame),
+  handler: async (ctx) => {
+    const { steps, maxGap, startDate, endDate } = ctx.state.validated.body
+
+    const result = await computeFunnel({
+      clickhouse: ctx.clickhouse,
+      game: ctx.state.game,
+      includeDevData: ctx.state.includeDevData,
+      steps,
+      maxGap,
+      startDate,
+      endDate,
+    })
+
+    return {
+      status: 200,
+      body: {
+        result: {
+          steps: result,
+          lastUpdatedAt: Date.now(),
+        },
+      },
+    }
+  },
+})

--- a/src/routes/protected/event-funnel/refresh.ts
+++ b/src/routes/protected/event-funnel/refresh.ts
@@ -1,0 +1,18 @@
+import EventFunnel from '../../../entities/event-funnel.js'
+import { clearResponseCache } from '../../../lib/perf/responseCache.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { loadFunnel } from './common.js'
+
+export const refreshRoute = protectedRoute({
+  method: 'delete',
+  path: '/:id/refresh',
+  middleware: withMiddleware(loadGame, loadFunnel),
+  handler: async (ctx) => {
+    await clearResponseCache(`${EventFunnel.getCacheKey(ctx.state.game, ctx.state.funnel.id)}-*`)
+
+    return {
+      status: 204,
+    }
+  },
+})

--- a/src/routes/protected/event-funnel/update.ts
+++ b/src/routes/protected/event-funnel/update.ts
@@ -1,0 +1,30 @@
+import EventFunnel from '../../../entities/event-funnel.js'
+import updateAllowedKeys from '../../../lib/entities/updateAllowedKeys.js'
+import { clearResponseCache } from '../../../lib/perf/responseCache.js'
+import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { loadGame } from '../../../middleware/game-middleware.js'
+import { loadFunnel, updateFunnelSchema } from './common.js'
+
+export const updateRoute = protectedRoute({
+  method: 'patch',
+  path: '/:id',
+  schema: () => ({
+    body: updateFunnelSchema,
+  }),
+  middleware: withMiddleware(loadGame, loadFunnel),
+  handler: async (ctx) => {
+    const body = ctx.state.validated.body
+    const funnel = ctx.state.funnel
+
+    updateAllowedKeys(funnel, body, ['name', 'steps', 'maxGap'])
+    await ctx.em.flush()
+    await clearResponseCache(`${EventFunnel.getCacheKey(ctx.state.game, funnel.id)}-*`)
+
+    return {
+      status: 200,
+      body: {
+        funnel,
+      },
+    }
+  },
+})

--- a/tests/routes/protected/event-funnel/create.test.ts
+++ b/tests/routes/protected/event-funnel/create.test.ts
@@ -1,0 +1,144 @@
+import request from 'supertest'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - create', () => {
+  it('should create a funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Onboarding',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnel).toMatchObject({
+      name: 'Onboarding',
+      maxGap: 60,
+    })
+    expect(res.body.funnel.steps).toEqual([
+      { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+      { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+    ])
+  })
+
+  it('should reject duplicate step names', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+
+    expect(res.body.errors.steps[0]).toBe('Step names must be distinct')
+  })
+
+  it('should reject a between rule with a single value', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          {
+            name: 'Shop Opened',
+            props: {
+              ruleMode: 'and',
+              rules: [{ key: 'amount', op: 'between', value: ['10'] }],
+            },
+          },
+          { name: 'Purchase Completed', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should reject a funnel with a single step', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [{ name: 'Game Started', props: { ruleMode: 'and', rules: [] } }],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should reject a non-positive max gap', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 0,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should not create a funnel for a non-existent game', async () => {
+    const [token] = await createUserAndToken()
+
+    await request(app)
+      .post('/games/99999/event-funnels')
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should not create a funnel for a game the user has no access to', async () => {
+    const [, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken()
+
+    await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(403)
+  })
+})

--- a/tests/routes/protected/event-funnel/delete.test.ts
+++ b/tests/routes/protected/event-funnel/delete.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - delete', () => {
+  it('should delete a funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    await request(app)
+      .delete(`/games/${game.id}/event-funnels/${funnelId}`)
+      .auth(token, { type: 'bearer' })
+      .expect(204)
+
+    await request(app)
+      .get(`/games/${game.id}/event-funnels/${funnelId}`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should return 404 for a non-existent funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .delete(`/games/${game.id}/event-funnels/99999`)
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should not delete a funnel from another game', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [otherOrganisation, otherGame] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+    const [otherToken] = await createUserAndToken({}, otherOrganisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    await request(app)
+      .delete(`/games/${otherGame.id}/event-funnels/${funnelId}`)
+      .auth(otherToken, { type: 'bearer' })
+      .expect(404)
+  })
+})

--- a/tests/routes/protected/event-funnel/get.test.ts
+++ b/tests/routes/protected/event-funnel/get.test.ts
@@ -1,0 +1,202 @@
+import { addSeconds } from 'date-fns'
+import request from 'supertest'
+import EventFactory from '../../../fixtures/EventFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - get', () => {
+  it('should return a funnel with computed results', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).one()
+    await em.persist(player).flush()
+    const playerAlias = player.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([player])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias }))
+        .one(),
+      await new EventFactory([player])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    const res = await request(app)
+      .get(`/games/${game.id}/event-funnels/${createRes.body.funnel.id}`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnel.name).toBe('Funnel')
+    expect(res.body.result.steps).toEqual([
+      { eventName: 'Game Started', players: 1, percentage: 100, avgSecondsToNext: 30 },
+      { eventName: 'Chest Looted', players: 1, percentage: 100, avgSecondsToNext: null },
+    ])
+    expect(res.body.result.lastUpdatedAt).toEqual(expect.any(Number))
+  })
+
+  it('should include dev build players when dev data is requested', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).devBuild().one()
+    await em.persist(player).flush()
+    const playerAlias = player.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([player])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias }))
+        .one(),
+      await new EventFactory([player])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    const withoutDev = await request(app)
+      .get(`/games/${game.id}/event-funnels/${createRes.body.funnel.id}`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    expect(withoutDev.body.result.steps[0].players).toBe(0)
+
+    const withDev = await request(app)
+      .get(`/games/${game.id}/event-funnels/${createRes.body.funnel.id}`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .set('x-talo-include-dev-data', '1')
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    expect(withDev.body.result.steps[0].players).toBe(1)
+  })
+
+  it('should reject a missing date window', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    await request(app)
+      .get(`/games/${game.id}/event-funnels/${createRes.body.funnel.id}`)
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should reject a partial date window', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    await request(app)
+      .get(`/games/${game.id}/event-funnels/${createRes.body.funnel.id}`)
+      .query({ startDate: '2026-09-01' })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should return 404 for a non-existent funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .get(`/games/${game.id}/event-funnels/99999`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should not return a funnel from another game', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [otherOrganisation, otherGame] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+    const [otherToken] = await createUserAndToken({}, otherOrganisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    await request(app)
+      .get(`/games/${otherGame.id}/event-funnels/${createRes.body.funnel.id}`)
+      .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+      .auth(otherToken, { type: 'bearer' })
+      .expect(404)
+  })
+})

--- a/tests/routes/protected/event-funnel/list.test.ts
+++ b/tests/routes/protected/event-funnel/list.test.ts
@@ -1,0 +1,58 @@
+import request from 'supertest'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - list', () => {
+  it('should list funnels for a game', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const create = (name: string) =>
+      request(app)
+        .post(`/games/${game.id}/event-funnels`)
+        .send({
+          name,
+          steps: [
+            { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+            { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+          ],
+          maxGap: 60,
+        })
+        .auth(token, { type: 'bearer' })
+
+    await create('One').expect(200)
+    await create('Two').expect(200)
+
+    const res = await request(app)
+      .get(`/games/${game.id}/event-funnels`)
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnels).toHaveLength(2)
+    expect(res.body.funnels.map((funnel: { name: string }) => funnel.name)).toEqual(
+      expect.arrayContaining(['One', 'Two']),
+    )
+  })
+
+  it('should return an empty list when no funnels exist', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const res = await request(app)
+      .get(`/games/${game.id}/event-funnels`)
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnels).toEqual([])
+  })
+
+  it('should not list funnels for a game the user has no access to', async () => {
+    const [, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken()
+
+    await request(app)
+      .get(`/games/${game.id}/event-funnels`)
+      .auth(token, { type: 'bearer' })
+      .expect(403)
+  })
+})

--- a/tests/routes/protected/event-funnel/preview.test.ts
+++ b/tests/routes/protected/event-funnel/preview.test.ts
@@ -1,0 +1,230 @@
+import { addSeconds } from 'date-fns'
+import request from 'supertest'
+import EventFactory from '../../../fixtures/EventFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - preview', () => {
+  it('should compute a basic funnel with percentages and avg time to convert', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const playerA = await new PlayerFactory([game]).one()
+    const playerB = await new PlayerFactory([game]).one()
+    await em.persist([playerA, playerB]).flush()
+    const aliasA = playerA.aliases.getItems()[0]
+    const aliasB = playerB.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([playerA])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: aliasA }))
+        .one(),
+      await new EventFactory([playerA])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias: aliasA,
+        }))
+        .one(),
+      await new EventFactory([playerB])
+        .state(() => ({
+          name: 'Game Started',
+          createdAt: addSeconds(baseTime, 5),
+          playerAlias: aliasB,
+        }))
+        .one(),
+      await new EventFactory([playerB])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 45),
+          playerAlias: aliasB,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+        startDate: '2026-09-01',
+        endDate: '2026-09-02',
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.result.steps).toEqual([
+      { eventName: 'Game Started', players: 2, percentage: 100, avgSecondsToNext: 35 },
+      { eventName: 'Chest Looted', players: 2, percentage: 100, avgSecondsToNext: null },
+    ])
+  })
+
+  it('should exclude out-of-order events and events outside the max gap', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const playerA = await new PlayerFactory([game]).one()
+    const playerB = await new PlayerFactory([game]).one()
+    await em.persist([playerA, playerB]).flush()
+    const aliasA = playerA.aliases.getItems()[0]
+    const aliasB = playerB.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      // playerA: loot happens before game start
+      await new EventFactory([playerA])
+        .state(() => ({ name: 'Chest Looted', createdAt: baseTime, playerAlias: aliasA }))
+        .one(),
+      await new EventFactory([playerA])
+        .state(() => ({
+          name: 'Game Started',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias: aliasA,
+        }))
+        .one(),
+      // playerB: start and loot 90s apart, beyond the 60s max gap
+      await new EventFactory([playerB])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: aliasB }))
+        .one(),
+      await new EventFactory([playerB])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 90),
+          playerAlias: aliasB,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+        startDate: '2026-09-01',
+        endDate: '2026-09-02',
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.result.steps[0].players).toBe(2)
+    expect(res.body.result.steps[1].players).toBe(0)
+  })
+
+  it('should exclude events outside the date window', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).one()
+    await em.persist(player).flush()
+    const alias = player.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([player])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: alias }))
+        .one(),
+      await new EventFactory([player])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias: alias,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+        startDate: '2026-09-20',
+        endDate: '2026-09-21',
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.result.steps[0].players).toBe(0)
+    expect(res.body.result.steps[0].percentage).toBe(0)
+    expect(res.body.result.steps[1].players).toBe(0)
+    expect(res.body.result.steps[1].percentage).toBe(0)
+  })
+
+  it('should exclude dev build players unless dev data is included', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).devBuild().one()
+    await em.persist(player).flush()
+    const alias = player.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([player])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: alias }))
+        .one(),
+      await new EventFactory([player])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias: alias,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const body = {
+      steps: [
+        { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+        { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+      ],
+      maxGap: 60,
+      startDate: '2026-09-01',
+      endDate: '2026-09-02',
+    }
+
+    const withoutDev = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send(body)
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    expect(withoutDev.body.result.steps[0].players).toBe(0)
+
+    const withDev = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send(body)
+      .set('x-talo-include-dev-data', '1')
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    expect(withDev.body.result.steps[0].players).toBe(1)
+  })
+})

--- a/tests/routes/protected/event-funnel/refresh.test.ts
+++ b/tests/routes/protected/event-funnel/refresh.test.ts
@@ -1,0 +1,112 @@
+import { addSeconds } from 'date-fns'
+import request from 'supertest'
+import EventFactory from '../../../fixtures/EventFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - refresh', () => {
+  it('should bust a funnels cached results', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).one()
+    const secondPlayer = await new PlayerFactory([game]).one()
+    await em.persist([player, secondPlayer]).flush()
+    const playerAlias = player.aliases.getItems()[0]
+    const otherAlias = secondPlayer.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const firstEvent = await new EventFactory([player])
+      .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias }))
+      .one()
+    await clickhouse.insert({
+      table: 'events',
+      values: [firstEvent.toInsertable()],
+      format: 'JSONEachRow',
+    })
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    const get = () =>
+      request(app)
+        .get(`/games/${game.id}/event-funnels/${funnelId}`)
+        .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+        .auth(token, { type: 'bearer' })
+
+    const first = await get().expect(200)
+    expect(first.body.result.steps[0].players).toBe(1)
+
+    // cached result should not reflect the new event
+    const secondEvent = await new EventFactory([secondPlayer])
+      .state(() => ({
+        name: 'Game Started',
+        createdAt: addSeconds(baseTime, 10),
+        playerAlias: otherAlias,
+      }))
+      .one()
+    await clickhouse.insert({
+      table: 'events',
+      values: [secondEvent.toInsertable()],
+      format: 'JSONEachRow',
+    })
+    const cached = await get().expect(200)
+    expect(cached.body.result.steps[0].players).toBe(1)
+
+    await request(app)
+      .delete(`/games/${game.id}/event-funnels/${funnelId}/refresh`)
+      .auth(token, { type: 'bearer' })
+      .expect(204)
+
+    const fresh = await get().expect(200)
+    expect(fresh.body.result.steps[0].players).toBe(2)
+  })
+
+  it('should return 404 for a non-existent funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .delete(`/games/${game.id}/event-funnels/99999/refresh`)
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should not refresh a funnel from another game', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [otherOrganisation, otherGame] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+    const [otherToken] = await createUserAndToken({}, otherOrganisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    await request(app)
+      .delete(`/games/${otherGame.id}/event-funnels/${funnelId}/refresh`)
+      .auth(otherToken, { type: 'bearer' })
+      .expect(404)
+  })
+})

--- a/tests/routes/protected/event-funnel/rules.test.ts
+++ b/tests/routes/protected/event-funnel/rules.test.ts
@@ -1,0 +1,260 @@
+import { addSeconds } from 'date-fns'
+import request from 'supertest'
+import Game from '../../../../src/entities/game.js'
+import EventFactory from '../../../fixtures/EventFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+const baseTime = new Date('2026-09-01T10:00:00Z')
+
+// players 1-4 and 6 have props on their kill event; player 5 has none
+const playerProps: { key: string; value: string }[][] = [
+  [
+    { key: 'weapon', value: 'iron-sword' },
+    { key: 'amount', value: '25' },
+    { key: 'level', value: '5' },
+  ],
+  [
+    { key: 'weapon', value: 'axe' },
+    { key: 'amount', value: '10' },
+    { key: 'level', value: '5' },
+  ],
+  [
+    { key: 'weapon', value: 'bow' },
+    { key: 'amount', value: '50' },
+    { key: 'level', value: '7' },
+  ],
+  [
+    { key: 'weapon', value: 'sword' },
+    { key: 'amount', value: 'banana' },
+    { key: 'level', value: '9' },
+  ],
+  [],
+  [
+    { key: 'weapon', value: 'sword' },
+    { key: 'amount', value: '10.0' },
+    { key: 'level', value: '6' },
+  ],
+]
+
+async function setup(game: Game) {
+  for (const props of playerProps) {
+    const player = await new PlayerFactory([game]).one()
+    await em.persist(player).flush()
+    const playerAlias = player.aliases.getItems()[0]
+
+    const event = await new EventFactory([player])
+      .state(() => ({
+        name: 'Chest Looted',
+        createdAt: baseTime,
+        props,
+        playerAlias,
+      }))
+      .one()
+
+    await clickhouse.insert({
+      table: 'events',
+      values: [event.toInsertable()],
+      format: 'JSONEachRow',
+    })
+    await clickhouse.insert({
+      table: 'event_props',
+      values: event.getInsertableProps(),
+      format: 'JSONEachRow',
+    })
+  }
+}
+
+async function previewPlayers(
+  game: Game,
+  token: string,
+  rules: { key: string; op: string; value: string[] }[],
+) {
+  const res = await request(app)
+    .post(`/games/${game.id}/event-funnels/preview`)
+    .send({
+      steps: [
+        { name: 'Chest Looted', props: { ruleMode: 'and', rules } },
+        { name: 'Item Used', props: { ruleMode: 'and', rules: [] } },
+      ],
+      maxGap: 60,
+      startDate: '2026-09-01',
+      endDate: '2026-09-02',
+    })
+    .auth(token, { type: 'bearer' })
+    .expect(200)
+
+  return res.body.result.steps[0].players
+}
+
+describe('Event funnels - prop rules', () => {
+  let game: Game
+  let token: string
+
+  beforeEach(async () => {
+    const [organisation, createdGame] = await createOrganisationAndGame()
+    const [createdToken] = await createUserAndToken({}, organisation)
+    game = createdGame
+    token = createdToken
+    await setup(game)
+  })
+
+  it('matches set for a key that exists', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'weapon', op: 'set', value: [] }])).toBe(5)
+  })
+
+  it('does not match set for a key that is never set', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'armor', op: 'set', value: [] }])).toBe(0)
+  })
+
+  it('matches equals for strings', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'weapon', op: '=', value: ['sword'] }])).toBe(
+      2,
+    )
+  })
+
+  it('matches equals numerically when strings differ in format', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'amount', op: '=', value: ['10'] }])).toBe(2)
+  })
+
+  it('matches not equals', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'weapon', op: '!=', value: ['sword'] }])).toBe(
+      3,
+    )
+  })
+
+  it('matches greater than', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'amount', op: '>', value: ['20'] }])).toBe(2)
+  })
+
+  it('matches greater than or equal', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'amount', op: '>=', value: ['10'] }])).toBe(4)
+  })
+
+  it('matches less than', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'amount', op: '<', value: ['15'] }])).toBe(2)
+  })
+
+  it('matches less than or equal', async () => {
+    expect(await previewPlayers(game, token, [{ key: 'amount', op: '<=', value: ['10'] }])).toBe(2)
+  })
+
+  it('matches between', async () => {
+    expect(
+      await previewPlayers(game, token, [{ key: 'amount', op: 'between', value: ['20', '30'] }]),
+    ).toBe(1)
+  })
+
+  it('matches contains as a substring', async () => {
+    expect(
+      await previewPlayers(game, token, [{ key: 'weapon', op: 'contains', value: ['sword'] }]),
+    ).toBe(3)
+  })
+
+  it('combines rules with and mode', async () => {
+    expect(
+      await previewPlayers(game, token, [
+        { key: 'weapon', op: 'contains', value: ['sword'] },
+        { key: 'amount', op: '>', value: ['20'] },
+      ]),
+    ).toBe(1)
+  })
+
+  it('combines rules with or mode', async () => {
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send({
+        steps: [
+          {
+            name: 'Chest Looted',
+            props: {
+              ruleMode: 'or',
+              rules: [
+                { key: 'weapon', op: '=', value: ['axe'] },
+                { key: 'amount', op: '>', value: ['40'] },
+              ],
+            },
+          },
+          { name: 'Item Used', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+        startDate: '2026-09-01',
+        endDate: '2026-09-02',
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.result.steps[0].players).toBe(2)
+  })
+
+  it('does not filter when rules are empty', async () => {
+    expect(await previewPlayers(game, token, [])).toBe(6)
+  })
+
+  it('filters players on a later step', async () => {
+    const playerA = await new PlayerFactory([game]).one()
+    const playerB = await new PlayerFactory([game]).one()
+    await em.persist([playerA, playerB]).flush()
+    const aliasA = playerA.aliases.getItems()[0]
+    const aliasB = playerB.aliases.getItems()[0]
+
+    const events = [
+      await new EventFactory([playerA])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: aliasA }))
+        .one(),
+      await new EventFactory([playerA])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 10),
+          props: [{ key: 'weapon', value: 'sword' }],
+          playerAlias: aliasA,
+        }))
+        .one(),
+      await new EventFactory([playerB])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias: aliasB }))
+        .one(),
+      await new EventFactory([playerB])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 10),
+          props: [{ key: 'weapon', value: 'axe' }],
+          playerAlias: aliasB,
+        }))
+        .one(),
+    ]
+
+    for (const event of events) {
+      await clickhouse.insert({
+        table: 'events',
+        values: [event.toInsertable()],
+        format: 'JSONEachRow',
+      })
+      await clickhouse.insert({
+        table: 'event_props',
+        values: event.getInsertableProps(),
+        format: 'JSONEachRow',
+      })
+    }
+
+    const res = await request(app)
+      .post(`/games/${game.id}/event-funnels/preview`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          {
+            name: 'Chest Looted',
+            props: { ruleMode: 'and', rules: [{ key: 'weapon', op: '=', value: ['sword'] }] },
+          },
+        ],
+        maxGap: 60,
+        startDate: '2026-09-01',
+        endDate: '2026-09-02',
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.result.steps[0].players).toBe(2)
+    expect(res.body.result.steps[1].players).toBe(1)
+  })
+})

--- a/tests/routes/protected/event-funnel/update.test.ts
+++ b/tests/routes/protected/event-funnel/update.test.ts
@@ -1,0 +1,174 @@
+import { addSeconds } from 'date-fns'
+import request from 'supertest'
+import EventFactory from '../../../fixtures/EventFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
+import createUserAndToken from '../../../utils/createUserAndToken.js'
+
+describe('Event funnels - update', () => {
+  it('should update a funnels fields', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    const res = await request(app)
+      .patch(`/games/${game.id}/event-funnels/${funnelId}`)
+      .send({ name: 'Funnel v2', maxGap: 120 })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnel).toMatchObject({
+      name: 'Funnel v2',
+      maxGap: 120,
+    })
+  })
+
+  it('should clear the steps on a funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    const res = await request(app)
+      .patch(`/games/${game.id}/event-funnels/${funnelId}`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Item Used', props: { ruleMode: 'and', rules: [] } },
+        ],
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.funnel.steps).toEqual([
+      { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+      { name: 'Item Used', props: { ruleMode: 'and', rules: [] } },
+    ])
+  })
+
+  it('should bust the cached results on update', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player = await new PlayerFactory([game]).one()
+    await em.persist(player).flush()
+    const playerAlias = player.aliases.getItems()[0]
+
+    const baseTime = new Date('2026-09-01T10:00:00Z')
+    const events = [
+      await new EventFactory([player])
+        .state(() => ({ name: 'Game Started', createdAt: baseTime, playerAlias }))
+        .one(),
+      await new EventFactory([player])
+        .state(() => ({
+          name: 'Chest Looted',
+          createdAt: addSeconds(baseTime, 30),
+          playerAlias,
+        }))
+        .one(),
+    ]
+    await clickhouse.insert({
+      table: 'events',
+      values: events.map((event) => event.toInsertable()),
+      format: 'JSONEachRow',
+    })
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    const get = () =>
+      request(app)
+        .get(`/games/${game.id}/event-funnels/${funnelId}`)
+        .query({ startDate: '2026-09-01', endDate: '2026-09-02' })
+        .auth(token, { type: 'bearer' })
+
+    const cached = await get().expect(200)
+    expect(cached.body.funnel.name).toBe('Funnel')
+
+    await request(app)
+      .patch(`/games/${game.id}/event-funnels/${funnelId}`)
+      .send({ name: 'Funnel v2' })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    const fresh = await get().expect(200)
+    expect(fresh.body.funnel.name).toBe('Funnel v2')
+  })
+
+  it('should return 404 for a non-existent funnel', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    await request(app)
+      .patch(`/games/${game.id}/event-funnels/99999`)
+      .send({ name: 'Nope' })
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should reject duplicate step names on update', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const createRes = await request(app)
+      .post(`/games/${game.id}/event-funnels`)
+      .send({
+        name: 'Funnel',
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Chest Looted', props: { ruleMode: 'and', rules: [] } },
+        ],
+        maxGap: 60,
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+    const funnelId = createRes.body.funnel.id
+
+    await request(app)
+      .patch(`/games/${game.id}/event-funnels/${funnelId}`)
+      .send({
+        steps: [
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+          { name: 'Game Started', props: { ruleMode: 'and', rules: [] } },
+        ],
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+})


### PR DESCRIPTION
**Event funnel model**
- Add an `EventFunnel` entity storing a name, an ordered list of steps, and a max gap between steps, with a database migration and registration in the entities index.
- Add full CRUD endpoints under `/games/:gameId/event-funnels` (create, list, get, update, delete) scoped to the game, plus schema validation covering step names, rule operators, and max gap.

**ClickHouse funnel computation**
- Compute funnel conversion in ClickHouse by joining each step on the previous one for the same player, within the configured max gap and date window.
- Each step reports distinct player count, percentage relative to the first step, and average seconds to reach the next step.
- Support step property rules with operators (set, =, !=, comparison, between, contains) combined in and/or mode, and exclude dev build events unless dev data is requested.
- Add a preview endpoint to evaluate a funnel definition without persisting it.

**Caching**
- Cache computed funnel results per game, funnel, date window, and dev-data flag with a 15-minute TTL.
- Bust the cache on funnel update and via an explicit refresh endpoint so results stay current.