### PR TITLE
Support multiple integrations of the same type per game

### DIFF
--- a/src/entities/integration.ts
+++ b/src/entities/integration.ts
@@ -2,14 +2,8 @@ import { Entity, Enum, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decora
 import { EntityManager } from '@mikro-orm/mysql'
 import { pick } from 'lodash-es'
 import { decrypt, encrypt } from '../lib/crypto/string-encryption.js'
-import {
-  authenticateSignature,
-  AuthenticateSignatureResult,
-} from '../lib/integrations/game-center/game-center-players.js'
-import {
-  authenticateAuthCode,
-  AuthenticateAuthCodeResult,
-} from '../lib/integrations/google-play-games/google-play-games-players.js'
+import { authenticateSignature } from '../lib/integrations/game-center/game-center-players.js'
+import { authenticateAuthCode } from '../lib/integrations/google-play-games/google-play-games-players.js'
 import {
   cleanupSteamworksLeaderboardEntry,
   createSteamworksLeaderboard,
@@ -18,10 +12,7 @@ import {
   deleteSteamworksLeaderboardEntry,
   syncSteamworksLeaderboards,
 } from '../lib/integrations/steamworks/steamworks-leaderboards.js'
-import {
-  authenticateTicket,
-  AuthenticateTicketResult,
-} from '../lib/integrations/steamworks/steamworks-players.js'
+import { authenticateTicket } from '../lib/integrations/steamworks/steamworks-players.js'
 import {
   cleanupSteamworksPlayerStat,
   setSteamworksStat,
@@ -64,6 +55,14 @@ export type IntegrationConfigMap = {
 }
 
 export type IntegrationConfig = IntegrationConfigMap[keyof IntegrationConfigMap]
+
+type ResolveIdentifierResult = {
+  identifier: string
+  initialPlayerProps?: {
+    key: string
+    value: string
+  }[]
+}
 
 @Entity()
 export default class Integration<T extends IntegrationType = IntegrationType> {
@@ -289,14 +288,20 @@ export default class Integration<T extends IntegrationType = IntegrationType> {
   async getPlayerIdentifier(
     em: EntityManager,
     identifier: string,
-  ): Promise<AuthenticateTicketResult | AuthenticateAuthCodeResult | AuthenticateSignatureResult> {
+  ): Promise<ResolveIdentifierResult> {
     switch (this.type) {
-      case IntegrationType.STEAMWORKS:
-        return authenticateTicket(em, this, identifier)
-      case IntegrationType.GOOGLE_PLAY_GAMES:
-        return authenticateAuthCode(em, this, identifier)
-      case IntegrationType.GAME_CENTER:
-        return authenticateSignature(em, this, identifier)
+      case IntegrationType.STEAMWORKS: {
+        const { steamId, initialPlayerProps } = await authenticateTicket(em, this, identifier)
+        return { identifier: steamId, initialPlayerProps }
+      }
+      case IntegrationType.GOOGLE_PLAY_GAMES: {
+        const { playerId, initialPlayerProps } = await authenticateAuthCode(em, this, identifier)
+        return { identifier: playerId, initialPlayerProps }
+      }
+      case IntegrationType.GAME_CENTER: {
+        const { playerId, initialPlayerProps } = await authenticateSignature(em, this, identifier)
+        return { identifier: playerId, initialPlayerProps }
+      }
     }
   }
 

--- a/src/entities/player-alias.ts
+++ b/src/entities/player-alias.ts
@@ -9,9 +9,6 @@ import {
 } from '@mikro-orm/decorators/es'
 import { Collection, EntityManager } from '@mikro-orm/mysql'
 import { v4 } from 'uuid'
-import { AuthenticateSignatureResult } from '../lib/integrations/game-center/game-center-players.js'
-import { AuthenticateAuthCodeResult } from '../lib/integrations/google-play-games/google-play-games-players.js'
-import { AuthenticateTicketResult } from '../lib/integrations/steamworks/steamworks-players.js'
 import Socket from '../socket/index.js'
 import GameChannel, { GameChannelLeavingReason } from './game-channel.js'
 import Game from './game.js'
@@ -73,55 +70,55 @@ export default class PlayerAlias {
     const trimmedService = service.trim()
     const trimmedIdentifier = identifier.trim()
 
-    if (trimmedService === PlayerAliasService.STEAM) {
-      const integration = await em.repo(Integration).findOne({
-        game,
-        type: IntegrationType.STEAMWORKS,
-      })
+    const type = {
+      [PlayerAliasService.STEAM]: IntegrationType.STEAMWORKS,
+      [PlayerAliasService.GOOGLE_PLAY_GAMES]: IntegrationType.GOOGLE_PLAY_GAMES,
+      [PlayerAliasService.GAME_CENTER]: IntegrationType.GAME_CENTER,
+    }[trimmedService]
 
-      if (integration) {
-        const { steamId, initialPlayerProps } = (await integration.getPlayerIdentifier(
-          em,
-          trimmedIdentifier,
-        )) as AuthenticateTicketResult
+    if (!type) {
+      return { identifier: trimmedIdentifier }
+    }
 
-        return { identifier: steamId, initialPlayerProps }
+    return PlayerAlias.resolveWithIntegrations({
+      em,
+      game,
+      type,
+      identifier: trimmedIdentifier,
+    })
+  }
+
+  // try every integration for the service until one accepts the credentials
+  private static async resolveWithIntegrations({
+    em,
+    game,
+    type,
+    identifier,
+  }: {
+    em: EntityManager
+    game: Game
+    type: IntegrationType
+    identifier: string
+  }) {
+    // newest integrations first - their credentials are the most likely to be current
+    const integrations = await em
+      .repo(Integration)
+      .find({ game, type }, { orderBy: { createdAt: 'desc' } })
+
+    if (integrations.length === 0) {
+      return { identifier }
+    }
+
+    let lastError: unknown
+    for (const integration of integrations) {
+      try {
+        return await integration.getPlayerIdentifier(em, identifier)
+      } catch (err) {
+        lastError = err
       }
     }
 
-    if (trimmedService === PlayerAliasService.GOOGLE_PLAY_GAMES) {
-      const integration = await em.repo(Integration).findOne({
-        game,
-        type: IntegrationType.GOOGLE_PLAY_GAMES,
-      })
-
-      if (integration) {
-        const { playerId, initialPlayerProps } = (await integration.getPlayerIdentifier(
-          em,
-          trimmedIdentifier,
-        )) as AuthenticateAuthCodeResult
-
-        return { identifier: playerId, initialPlayerProps }
-      }
-    }
-
-    if (trimmedService === PlayerAliasService.GAME_CENTER) {
-      const integration = await em.repo(Integration).findOne({
-        game,
-        type: IntegrationType.GAME_CENTER,
-      })
-
-      if (integration) {
-        const { playerId, initialPlayerProps } = (await integration.getPlayerIdentifier(
-          em,
-          trimmedIdentifier,
-        )) as AuthenticateSignatureResult
-
-        return { identifier: playerId, initialPlayerProps }
-      }
-    }
-
-    return { identifier: trimmedIdentifier }
+    throw lastError
   }
 
   static getSocketDataKey(id: number) {

--- a/src/entities/steamworks-leaderboard-entry.ts
+++ b/src/entities/steamworks-leaderboard-entry.ts
@@ -1,19 +1,21 @@
-import { Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/decorators/es'
+import { Entity, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/es'
 import LeaderboardEntry from './leaderboard-entry.js'
 import SteamworksLeaderboardMapping from './steamworks-leaderboard-mapping.js'
 
 @Entity()
+@Unique({ properties: ['steamworksLeaderboard', 'leaderboardEntry'] })
 export class SteamworksLeaderboardEntry {
   @PrimaryKey()
   id!: number
 
   @ManyToOne(() => SteamworksLeaderboardMapping, {
     deleteRule: 'cascade',
-    fieldNames: ['steamworks_leaderboard_id', 'leaderboard_id'],
+    fieldNames: ['steamworks_leaderboard_id', 'leaderboard_id', 'integration_id'],
+    referencedColumnNames: ['steamworks_leaderboard_id', 'leaderboard_id', 'integration_id'],
   })
   steamworksLeaderboard: SteamworksLeaderboardMapping
 
-  @OneToOne(() => LeaderboardEntry, { nullable: true })
+  @ManyToOne(() => LeaderboardEntry, { nullable: true, deleteRule: 'set null' })
   leaderboardEntry: LeaderboardEntry | null
 
   @Property()

--- a/src/entities/steamworks-leaderboard-mapping.ts
+++ b/src/entities/steamworks-leaderboard-mapping.ts
@@ -1,10 +1,11 @@
 import { Entity, ManyToOne, PrimaryKey, Property } from '@mikro-orm/decorators/es'
 import { PrimaryKeyProp } from '@mikro-orm/mysql'
+import Integration from './integration.js'
 import Leaderboard from './leaderboard.js'
 
 @Entity()
 export default class SteamworksLeaderboardMapping {
-  [PrimaryKeyProp]?: ['steamworksLeaderboardId', 'leaderboard']
+  [PrimaryKeyProp]?: ['steamworksLeaderboardId', 'leaderboard', 'integration']
 
   @PrimaryKey()
   steamworksLeaderboardId: number
@@ -12,11 +13,23 @@ export default class SteamworksLeaderboardMapping {
   @ManyToOne(() => Leaderboard, { primary: true, deleteRule: 'cascade', nullable: false })
   leaderboard: Leaderboard
 
+  @ManyToOne(() => Integration, { primary: true, deleteRule: 'cascade', nullable: false })
+  integration: Integration
+
   @Property()
   createdAt: Date = new Date()
 
-  constructor(steamworksLeaderboardId: number, leaderboard: Leaderboard) {
+  constructor({
+    steamworksLeaderboardId,
+    leaderboard,
+    integration,
+  }: {
+    steamworksLeaderboardId: number
+    leaderboard: Leaderboard
+    integration: Integration
+  }) {
     this.steamworksLeaderboardId = steamworksLeaderboardId
     this.leaderboard = leaderboard
+    this.integration = integration
   }
 }

--- a/src/entities/steamworks-player-stat.ts
+++ b/src/entities/steamworks-player-stat.ts
@@ -1,8 +1,10 @@
-import { Entity, ManyToOne, OneToOne, PrimaryKey, Property } from '@mikro-orm/decorators/es'
+import { Entity, ManyToOne, PrimaryKey, Property, Unique } from '@mikro-orm/decorators/es'
 import GameStat from './game-stat.js'
+import Integration from './integration.js'
 import PlayerGameStat from './player-game-stat.js'
 
 @Entity()
+@Unique({ properties: ['integration', 'playerStat'] })
 export class SteamworksPlayerStat {
   @PrimaryKey()
   id!: number
@@ -10,7 +12,10 @@ export class SteamworksPlayerStat {
   @ManyToOne(() => GameStat, { deleteRule: 'cascade' })
   stat: GameStat
 
-  @OneToOne(() => PlayerGameStat, { nullable: true })
+  @ManyToOne(() => Integration, { deleteRule: 'cascade' })
+  integration: Integration
+
+  @ManyToOne(() => PlayerGameStat, { nullable: true, deleteRule: 'set null' })
   playerStat: PlayerGameStat | null
 
   @Property()
@@ -24,14 +29,17 @@ export class SteamworksPlayerStat {
 
   constructor({
     stat,
+    integration,
     playerStat,
     steamUserId,
   }: {
     stat: GameStat
+    integration: Integration
     playerStat: PlayerGameStat | null
     steamUserId: string
   }) {
     this.stat = stat
+    this.integration = integration
     this.playerStat = playerStat
     this.steamUserId = steamUserId
   }

--- a/src/lib/integrations/steamworks/steamworks-leaderboards.ts
+++ b/src/lib/integrations/steamworks/steamworks-leaderboards.ts
@@ -54,6 +54,7 @@ export async function createSteamworksLeaderboard(
     await em.repo(SteamworksLeaderboardMapping).upsert({
       steamworksLeaderboardId: steamworksLeaderboard.leaderBoardID,
       leaderboard,
+      integration,
       createdAt: new Date(),
     })
   }
@@ -84,9 +85,10 @@ export async function createSteamworksLeaderboardEntry(
   integration: Integration,
   entry: LeaderboardEntry,
 ) {
-  const leaderboardMapping = await em
-    .repo(SteamworksLeaderboardMapping)
-    .findOne({ leaderboard: entry.leaderboard })
+  const leaderboardMapping = await em.repo(SteamworksLeaderboardMapping).findOne({
+    leaderboard: entry.leaderboard,
+    integration,
+  })
 
   if (leaderboardMapping) {
     const body = querystring.stringify({
@@ -148,9 +150,10 @@ export async function deleteSteamworksLeaderboardEntry(
   integration: Integration,
   entry: LeaderboardEntry,
 ) {
-  const leaderboardMapping = await em
-    .repo(SteamworksLeaderboardMapping)
-    .findOne({ leaderboard: entry.leaderboard })
+  const leaderboardMapping = await em.repo(SteamworksLeaderboardMapping).findOne({
+    leaderboard: entry.leaderboard,
+    integration,
+  })
 
   if (leaderboardMapping) {
     const { event } = await requestDeleteLeaderboardScore({
@@ -220,10 +223,12 @@ function createLeaderboardEntry({
 
 async function matchAliasAndLeaderboardEntry({
   em,
+  integration,
   steamworksLeaderboard,
   steamEntryData,
 }: {
   em: EntityManager
+  integration: Integration
   steamworksLeaderboard: GetLeaderboardsForGameResponseLeaderboard
   steamEntryData: GetLeaderboardEntriesResponseEntry
 }) {
@@ -231,9 +236,12 @@ async function matchAliasAndLeaderboardEntry({
   const leaderboardMapping = await em.repo(SteamworksLeaderboardMapping).findOneOrFail(
     {
       steamworksLeaderboardId: steamworksLeaderboard.id,
+      integration,
     },
     {
-      ...getResultCacheOptions(`sync-leaderboards-mapping-${steamworksLeaderboard.id}`),
+      ...getResultCacheOptions(
+        `sync-leaderboards-mapping-${integration.id}-${steamworksLeaderboard.id}`,
+      ),
       populate: ['leaderboard.game'],
     },
   )
@@ -297,6 +305,7 @@ async function ingestEntriesFromSteamworks({
       const { newEntry, updated } = await em.fork().transactional((trx) => {
         return matchAliasAndLeaderboardEntry({
           em: trx,
+          integration,
           steamworksLeaderboard,
           steamEntryData,
         })
@@ -380,9 +389,10 @@ export async function syncSteamworksLeaderboards(em: EntityManager, integration:
 
   const combinedLeaderboards = await Promise.all(
     leaderboards.map(async (leaderboard): Promise<CombinedLeaderboards> => {
-      const leaderboardMapping = await em
-        .repo(SteamworksLeaderboardMapping)
-        .findOne({ leaderboard })
+      const leaderboardMapping = await em.repo(SteamworksLeaderboardMapping).findOne({
+        leaderboard,
+        integration,
+      })
 
       const mappingMatch = steamworksLeaderboards.find(
         (steamworksLeaderboard) =>
@@ -401,7 +411,13 @@ export async function syncSteamworksLeaderboards(em: EntityManager, integration:
       // update talo leaderboards with properties from steamworks - because we can't do the other way around
       if (leaderboard && steamworksLeaderboard) {
         if (!leaderboardMapping)
-          trx.persist(new SteamworksLeaderboardMapping(steamworksLeaderboard.id, leaderboard))
+          trx.persist(
+            new SteamworksLeaderboardMapping({
+              steamworksLeaderboardId: steamworksLeaderboard.id,
+              leaderboard: leaderboard,
+              integration: integration,
+            }),
+          )
 
         leaderboard.internalName = leaderboard.name = steamworksLeaderboard.name
         leaderboard.sortMode = mapSteamworksLeaderboardSortMode(steamworksLeaderboard.sortmethod)
@@ -426,7 +442,13 @@ export async function syncSteamworksLeaderboards(em: EntityManager, integration:
       leaderboard.sortMode = mapSteamworksLeaderboardSortMode(steamworksLeaderboard.sortmethod)
       leaderboard.unique = true
 
-      trx.persist(new SteamworksLeaderboardMapping(steamworksLeaderboard.id, leaderboard))
+      trx.persist(
+        new SteamworksLeaderboardMapping({
+          steamworksLeaderboardId: steamworksLeaderboard.id,
+          leaderboard: leaderboard,
+          integration: integration,
+        }),
+      )
       trx.persist(leaderboard)
       leaderboards.push(leaderboard)
     })

--- a/src/lib/integrations/steamworks/steamworks-stats.ts
+++ b/src/lib/integrations/steamworks/steamworks-stats.ts
@@ -79,6 +79,7 @@ export async function setSteamworksStat(
   await em.upsert(
     new SteamworksPlayerStat({
       stat: playerStat.stat,
+      integration,
       playerStat,
       steamUserId: playerAlias.identifier,
     }),
@@ -144,6 +145,7 @@ async function ingestSteamworksPlayerStatForAlias(
 
           const steamsWorksPlayerStat = new SteamworksPlayerStat({
             stat,
+            integration,
             playerStat,
             steamUserId: alias.identifier,
           })

--- a/src/lib/integrations/triggerIntegrations.ts
+++ b/src/lib/integrations/triggerIntegrations.ts
@@ -1,4 +1,5 @@
 import { EntityManager } from '@mikro-orm/mysql'
+import { captureException } from '@sentry/node'
 import Game from '../../entities/game.js'
 import Integration from '../../entities/integration.js'
 import { getResultCacheOptions } from '../perf/getResultCacheOptions.js'
@@ -12,5 +13,12 @@ export default async function triggerIntegrations(
     .repo(Integration)
     .find({ game }, getResultCacheOptions(Integration.getCacheKeyForGame(game)))
 
-  await Promise.all(integrations.map(async (integration) => await callback(integration)))
+  // one failing integration must not block the others
+  for (const integration of integrations) {
+    try {
+      await callback(integration)
+    } catch (err) {
+      captureException(err)
+    }
+  }
 }

--- a/src/migrations/.snapshot-gs_dev.json
+++ b/src/migrations/.snapshot-gs_dev.json
@@ -6699,6 +6699,23 @@
           "enumItems": [],
           "mappedType": "integer"
         },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
         "leaderboard_entry_id": {
           "name": "leaderboard_entry_id",
           "type": "int",
@@ -6706,7 +6723,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "unique": true,
+          "unique": false,
           "length": null,
           "precision": null,
           "scale": null,
@@ -6757,7 +6774,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
+          "unique": true,
           "length": null,
           "precision": null,
           "scale": null,
@@ -6797,16 +6814,29 @@
         {
           "columnNames": ["leaderboard_entry_id"],
           "composite": false,
+          "constraint": false,
+          "keyName": "steamworks_leaderboard_entry_leaderboard_entry_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": [
+            "steamworks_leaderboard_id",
+            "leaderboard_id",
+            "integration_id",
+            "leaderboard_entry_id"
+          ],
+          "composite": true,
           "constraint": true,
-          "keyName": "steamworks_leaderboard_entry_leaderboard_entry_id_unique",
+          "keyName": "steamworks_leaderboard_entry_steamworks_leaderboar_3f388_unique",
           "primary": false,
           "unique": true
         },
         {
-          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id"],
+          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id", "integration_id"],
           "composite": true,
           "constraint": false,
-          "keyName": "steamworks_leaderboard_entry_steamworks_leaderboard_47d69_index",
+          "keyName": "steamworks_leaderboard_entry_steamworks_leaderboard_54c77_index",
           "primary": false,
           "unique": false
         }
@@ -6822,11 +6852,15 @@
           "referencedTableName": "leaderboard_entry",
           "deleteRule": "set null"
         },
-        "steamworks_leaderboard_entry_steamworks_leaderboa_15279_foreign": {
-          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id"],
-          "constraintName": "steamworks_leaderboard_entry_steamworks_leaderboa_15279_foreign",
+        "steamworks_leaderboard_entry_steamworks_leaderboa_6bddf_foreign": {
+          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id", "integration_id"],
+          "constraintName": "steamworks_leaderboard_entry_steamworks_leaderboa_6bddf_foreign",
           "localTableName": "steamworks_leaderboard_entry",
-          "referencedColumnNames": ["steamworks_leaderboard_id", "leaderboard_id"],
+          "referencedColumnNames": [
+            "steamworks_leaderboard_id",
+            "leaderboard_id",
+            "integration_id"
+          ],
           "referencedTableName": "steamworks_leaderboard_mapping",
           "updateRule": "cascade",
           "deleteRule": "cascade"
@@ -6853,6 +6887,23 @@
           "collation": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
         },
         "leaderboard_id": {
           "name": "leaderboard_id",
@@ -6891,12 +6942,20 @@
       },
       "indexes": [
         {
-          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id"],
+          "columnNames": ["steamworks_leaderboard_id", "leaderboard_id", "integration_id"],
           "composite": true,
           "constraint": true,
           "keyName": "PRIMARY",
           "primary": true,
           "unique": true
+        },
+        {
+          "columnNames": ["integration_id"],
+          "composite": false,
+          "constraint": false,
+          "keyName": "steamworks_leaderboard_mapping_integration_id_index",
+          "primary": false,
+          "unique": false
         },
         {
           "columnNames": ["leaderboard_id"],
@@ -6910,6 +6969,14 @@
       "checks": [],
       "triggers": [],
       "foreignKeys": {
+        "steamworks_leaderboard_mapping_integration_id_foreign": {
+          "columnNames": ["integration_id"],
+          "constraintName": "steamworks_leaderboard_mapping_integration_id_foreign",
+          "localTableName": "steamworks_leaderboard_mapping",
+          "referencedColumnNames": ["id"],
+          "referencedTableName": "integration",
+          "deleteRule": "cascade"
+        },
         "steamworks_leaderboard_mapping_leaderboard_id_foreign": {
           "columnNames": ["leaderboard_id"],
           "constraintName": "steamworks_leaderboard_mapping_leaderboard_id_foreign",
@@ -6958,6 +7025,23 @@
           "enumItems": [],
           "mappedType": "integer"
         },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "int",
+          "unsigned": true,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "collation": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
         "player_stat_id": {
           "name": "player_stat_id",
           "type": "int",
@@ -6965,7 +7049,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": true,
-          "unique": true,
+          "unique": false,
           "length": null,
           "precision": null,
           "scale": null,
@@ -7037,12 +7121,28 @@
           "unique": true
         },
         {
-          "columnNames": ["player_stat_id"],
+          "columnNames": ["integration_id"],
           "composite": false,
+          "constraint": false,
+          "keyName": "steamworks_player_stat_integration_id_index",
+          "primary": false,
+          "unique": false
+        },
+        {
+          "columnNames": ["integration_id", "player_stat_id"],
+          "composite": true,
           "constraint": true,
-          "keyName": "steamworks_player_stat_player_stat_id_unique",
+          "keyName": "steamworks_player_stat_integration_id_player_stat_id_unique",
           "primary": false,
           "unique": true
+        },
+        {
+          "columnNames": ["player_stat_id"],
+          "composite": false,
+          "constraint": false,
+          "keyName": "steamworks_player_stat_player_stat_id_index",
+          "primary": false,
+          "unique": false
         },
         {
           "columnNames": ["stat_id"],
@@ -7056,6 +7156,14 @@
       "checks": [],
       "triggers": [],
       "foreignKeys": {
+        "steamworks_player_stat_integration_id_foreign": {
+          "columnNames": ["integration_id"],
+          "constraintName": "steamworks_player_stat_integration_id_foreign",
+          "localTableName": "steamworks_player_stat",
+          "referencedColumnNames": ["id"],
+          "referencedTableName": "integration",
+          "deleteRule": "cascade"
+        },
         "steamworks_player_stat_player_stat_id_foreign": {
           "columnNames": ["player_stat_id"],
           "constraintName": "steamworks_player_stat_player_stat_id_foreign",

--- a/src/migrations/20260905070622LinkSteamworksEntitiesToIntegration.ts
+++ b/src/migrations/20260905070622LinkSteamworksEntitiesToIntegration.ts
@@ -1,0 +1,114 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class LinkSteamworksEntitiesToIntegration extends Migration {
+  override up(): void | Promise<void> {
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` add \`integration_id\` int unsigned null;`,
+    )
+    this.addSql(`alter table \`steamworks_player_stat\` add \`integration_id\` int unsigned null;`)
+
+    // purge orphans - rows whose game has no steamworks integration can't be
+    // backfilled and would fail the not-null modify below
+    this.addSql(`
+      delete slm from steamworks_leaderboard_mapping slm
+        left join leaderboard l on l.id = slm.leaderboard_id
+        left join integration i on i.game_id = l.game_id and i.type = 'steamworks'
+      where i.id is null
+    `)
+    this.addSql(`
+      delete sps from steamworks_player_stat sps
+        left join game_stat gs on gs.id = sps.stat_id
+        left join integration i on i.game_id = gs.game_id and i.type = 'steamworks'
+      where i.id is null
+    `)
+
+    // backfill from the game's single steamworks integration
+    this.addSql(`
+      update steamworks_leaderboard_mapping slm
+        inner join leaderboard l on l.id = slm.leaderboard_id
+        inner join integration i on i.game_id = l.game_id and i.type = 'steamworks'
+      set slm.integration_id = i.id
+    `)
+    this.addSql(`
+      update steamworks_player_stat sps
+        inner join game_stat gs on gs.id = sps.stat_id
+        inner join integration i on i.game_id = gs.game_id and i.type = 'steamworks'
+      set sps.integration_id = i.id
+    `)
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` modify \`integration_id\` int unsigned not null;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` modify \`integration_id\` int unsigned not null;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` add constraint \`steamworks_leaderboard_mapping_integration_id_foreign\` foreign key (\`integration_id\`) references \`integration\` (\`id\`) on delete cascade;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` add index \`steamworks_leaderboard_mapping_integration_id_index\` (\`integration_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` add constraint \`steamworks_player_stat_integration_id_foreign\` foreign key (\`integration_id\`) references \`integration\` (\`id\`) on delete cascade;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` add index \`steamworks_player_stat_integration_id_index\` (\`integration_id\`);`,
+    )
+
+    // plain indexes first - the FKs depend on the uniques being replaced
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add index \`steamworks_leaderboard_entry_leaderboard_entry_id_index\` (\`leaderboard_entry_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop index \`steamworks_leaderboard_entry_leaderboard_entry_id_unique\`;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` add index \`steamworks_player_stat_player_stat_id_index\` (\`player_stat_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` drop index \`steamworks_player_stat_player_stat_id_unique\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_player_stat\` add unique \`steamworks_player_stat_integration_id_player_stat_id_unique\` (\`integration_id\`, \`player_stat_id\`);`,
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` drop foreign key \`steamworks_leaderboard_mapping_integration_id_foreign\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_player_stat\` drop foreign key \`steamworks_player_stat_integration_id_foreign\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_player_stat\` drop index \`steamworks_player_stat_integration_id_player_stat_id_unique\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_player_stat\` add unique \`steamworks_player_stat_player_stat_id_unique\` (\`player_stat_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` drop index \`steamworks_player_stat_player_stat_id_index\`;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_player_stat\` drop index \`steamworks_player_stat_integration_id_index\`;`,
+    )
+    this.addSql(`alter table \`steamworks_player_stat\` drop column \`integration_id\`;`)
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add unique \`steamworks_leaderboard_entry_leaderboard_entry_id_unique\` (\`leaderboard_entry_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop index \`steamworks_leaderboard_entry_leaderboard_entry_id_index\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` drop index \`steamworks_leaderboard_mapping_integration_id_index\`;`,
+    )
+    this.addSql(`alter table \`steamworks_leaderboard_mapping\` drop column \`integration_id\`;`)
+  }
+}

--- a/src/migrations/20260905094358WidenSteamworksLeaderboardMappingPk.ts
+++ b/src/migrations/20260905094358WidenSteamworksLeaderboardMappingPk.ts
@@ -1,0 +1,69 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class WidenSteamworksLeaderboardMappingPk extends Migration {
+  override up(): void | Promise<void> {
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop foreign key \`steamworks_leaderboard_entry_steamworks_leaderboa_15279_foreign\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop index \`steamworks_leaderboard_entry_steamworks_leaderboard_47d69_index\`;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add \`integration_id\` int unsigned null;`,
+    )
+
+    this.addSql(`alter table \`steamworks_leaderboard_mapping\` drop primary key;`)
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` add primary key (\`steamworks_leaderboard_id\`, \`leaderboard_id\`, \`integration_id\`);`,
+    )
+
+    // copy the integration from the entry's mapping
+    this.addSql(`
+      update steamworks_leaderboard_entry se
+        inner join steamworks_leaderboard_mapping sm
+          on sm.steamworks_leaderboard_id = se.steamworks_leaderboard_id
+          and sm.leaderboard_id = se.leaderboard_id
+      set se.integration_id = sm.integration_id
+    `)
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` modify \`integration_id\` int unsigned not null;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add constraint \`steamworks_leaderboard_entry_steamworks_leaderboa_6bddf_foreign\` foreign key (\`steamworks_leaderboard_id\`, \`leaderboard_id\`, \`integration_id\`) references \`steamworks_leaderboard_mapping\` (\`steamworks_leaderboard_id\`, \`leaderboard_id\`, \`integration_id\`) on update cascade on delete cascade;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add index \`steamworks_leaderboard_entry_steamworks_leaderboard_54c77_index\` (\`steamworks_leaderboard_id\`, \`leaderboard_id\`, \`integration_id\`);`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add unique \`steamworks_leaderboard_entry_steamworks_leaderboar_3f388_unique\` (\`steamworks_leaderboard_id\`, \`leaderboard_id\`, \`integration_id\`, \`leaderboard_entry_id\`);`,
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop foreign key \`steamworks_leaderboard_entry_steamworks_leaderboa_6bddf_foreign\`;`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop index \`steamworks_leaderboard_entry_steamworks_leaderboard_54c77_index\`;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` drop index \`steamworks_leaderboard_entry_steamworks_leaderboar_3f388_unique\`;`,
+    )
+    this.addSql(`alter table \`steamworks_leaderboard_entry\` drop column \`integration_id\`;`)
+
+    this.addSql(`alter table \`steamworks_leaderboard_mapping\` drop primary key;`)
+    this.addSql(
+      `alter table \`steamworks_leaderboard_mapping\` add primary key (\`steamworks_leaderboard_id\`, \`leaderboard_id\`);`,
+    )
+
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add constraint \`steamworks_leaderboard_entry_steamworks_leaderboa_15279_foreign\` foreign key (\`steamworks_leaderboard_id\`, \`leaderboard_id\`) references \`steamworks_leaderboard_mapping\` (\`steamworks_leaderboard_id\`, \`leaderboard_id\`) on update cascade on delete cascade;`,
+    )
+    this.addSql(
+      `alter table \`steamworks_leaderboard_entry\` add index \`steamworks_leaderboard_entry_steamworks_leaderboard_47d69_index\` (\`steamworks_leaderboard_id\`, \`leaderboard_id\`);`,
+    )
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -81,6 +81,8 @@ import { AddOrganisationAndUserDeletedAtColumns } from './20260830202536AddOrgan
 import { AddPlayersToDeleteUniqueConstraint } from './20260831000000AddPlayersToDeleteUniqueConstraint.js'
 import { CreateEventFunnelsTable } from './20260902191008CreateEventFunnelsTable.js'
 import { RemoveIntegrationSoftDelete } from './20260905054226RemoveIntegrationSoftDelete.js'
+import { LinkSteamworksEntitiesToIntegration } from './20260905070622LinkSteamworksEntitiesToIntegration.js'
+import { WidenSteamworksLeaderboardMappingPk } from './20260905094358WidenSteamworksLeaderboardMappingPk.js'
 
 export default [
   InitialMigration,
@@ -166,4 +168,6 @@ export default [
   AddPlayersToDeleteUniqueConstraint,
   CreateEventFunnelsTable,
   RemoveIntegrationSoftDelete,
+  LinkSteamworksEntitiesToIntegration,
+  WidenSteamworksLeaderboardMappingPk,
 ]

--- a/src/routes/protected/integration/common.ts
+++ b/src/routes/protected/integration/common.ts
@@ -83,3 +83,46 @@ export const configKeys: IntegrationConfigKeys = {
   [IntegrationType.GOOGLE_PLAY_GAMES]: ['clientId', 'clientSecret'],
   [IntegrationType.GAME_CENTER]: ['bundleId'],
 }
+
+function getAppIdentity(config: Record<string, unknown>): {
+  key: string
+  value: string
+} {
+  if ('appId' in config) {
+    return { key: 'appId', value: String(config.appId) }
+  }
+  if ('clientId' in config) {
+    return { key: 'clientId', value: String(config.clientId) }
+  }
+  return { key: 'bundleId', value: String(config.bundleId) }
+}
+
+// returns the identity key (e.g. "appId") when another integration of the same
+// type already points at the same external app - two integrations of the same
+// type can't point at the same app, they would fight over the same remote data
+export async function findDuplicateAppIdentity({
+  ctx,
+  type,
+  config,
+  ignoreId,
+}: {
+  ctx: ProtectedRouteContext<{ game: Game }>
+  type: IntegrationType
+  config: Record<string, unknown>
+  ignoreId?: number
+}) {
+  const appIdentity = getAppIdentity(config).value
+
+  const integrations = await ctx.em.repo(Integration).find({ type, game: ctx.state.game })
+  for (const integration of integrations) {
+    if (integration.id === ignoreId) {
+      continue
+    }
+
+    const identity = getAppIdentity(integration.getConfig())
+    if (identity.value === appIdentity) {
+      return identity.key
+    }
+  }
+  return null
+}

--- a/src/routes/protected/integration/create.ts
+++ b/src/routes/protected/integration/create.ts
@@ -6,7 +6,7 @@ import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { loadGame } from '../../../middleware/game-middleware.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
-import { configKeys } from './common.js'
+import { configKeys, findDuplicateAppIdentity } from './common.js'
 
 export const createRoute = protectedRoute({
   method: 'post',
@@ -41,13 +41,16 @@ export const createRoute = protectedRoute({
     const { type, config } = ctx.state.validated.body
     const em = ctx.em
 
-    const existingIntegration = await em.repo(Integration).findOne({
+    const identityKey = await findDuplicateAppIdentity({
+      ctx,
       type,
-      game: ctx.state.game,
+      config,
     })
-
-    if (existingIntegration) {
-      return ctx.throw(400, `This game already has an integration for ${type}`)
+    if (identityKey) {
+      return ctx.throw(
+        400,
+        `This game already has an integration for ${type} with this ${identityKey}`,
+      )
     }
 
     const integration = new Integration(

--- a/src/routes/protected/integration/update.ts
+++ b/src/routes/protected/integration/update.ts
@@ -4,7 +4,7 @@ import { UserType } from '../../../entities/user.js'
 import createGameActivity from '../../../lib/logging/createGameActivity.js'
 import { protectedRoute, withMiddleware } from '../../../lib/routing/router.js'
 import { userTypeGate } from '../../../middleware/policy-middleware.js'
-import { loadIntegration, configKeys } from './common.js'
+import { loadIntegration, configKeys, findDuplicateAppIdentity } from './common.js'
 
 export const updateRoute = protectedRoute({
   method: 'patch',
@@ -33,6 +33,19 @@ export const updateRoute = protectedRoute({
     const integration = ctx.state.integration
     const newConfig = pick(config, configKeys[integration.type])
     integration.updateConfig(newConfig)
+
+    const identityKey = await findDuplicateAppIdentity({
+      ctx,
+      type: integration.type,
+      config: integration.getConfig(),
+      ignoreId: integration.id,
+    })
+    if (identityKey) {
+      return ctx.throw(
+        400,
+        `This game already has an integration for ${integration.type} with this ${identityKey}`,
+      )
+    }
 
     createGameActivity(em, {
       actor: ctx.state.user,

--- a/src/tasks/cleanupSteamworksLeaderboardEntries.ts
+++ b/src/tasks/cleanupSteamworksLeaderboardEntries.ts
@@ -1,7 +1,6 @@
-import { EntityManager, NotFoundError } from '@mikro-orm/mysql'
+import { EntityManager } from '@mikro-orm/mysql'
 import { captureException } from '@sentry/node'
 import { getMikroORM } from '../config/mikro-orm.config.js'
-import Integration, { IntegrationType } from '../entities/integration.js'
 import { SteamworksLeaderboardEntry } from '../entities/steamworks-leaderboard-entry.js'
 import { streamByCursor } from '../lib/perf/streamByCursor.js'
 
@@ -19,34 +18,18 @@ export default async function cleanupSteamworksLeaderboardEntries() {
       first: batchSize,
       after,
       orderBy: { id: 'asc' },
-      populate: ['steamworksLeaderboard.leaderboard.game'] as const,
+      populate: [
+        'steamworksLeaderboard.integration',
+        'steamworksLeaderboard.leaderboard.game',
+      ] as const,
     })
   }, 100)
 
-  const integrationsMap = new Map<number, Integration>()
   let processed = 0
 
   for await (const entry of entryStream) {
     try {
-      const game = entry.steamworksLeaderboard.leaderboard.game
-      let integration = integrationsMap.get(game.id)
-      if (!integration) {
-        try {
-          integration = await em
-            .repo(Integration)
-            .findOneOrFail({ game, type: IntegrationType.STEAMWORKS })
-        } catch (err) {
-          if (err instanceof NotFoundError) {
-            await em.repo(SteamworksLeaderboardEntry).nativeDelete(entry.id)
-            continue
-          }
-          /* v8 ignore next -- @preserve */
-          throw err
-        }
-        integrationsMap.set(game.id, integration)
-      }
-
-      await integration.cleanupSteamworksLeaderboardEntry(em, entry)
+      await entry.steamworksLeaderboard.integration.cleanupSteamworksLeaderboardEntry(em, entry)
       await new Promise((resolve) => setTimeout(resolve, 100))
     } catch (err) {
       console.error(

--- a/src/tasks/cleanupSteamworksPlayerStats.ts
+++ b/src/tasks/cleanupSteamworksPlayerStats.ts
@@ -1,7 +1,6 @@
-import { EntityManager, NotFoundError } from '@mikro-orm/mysql'
+import { EntityManager } from '@mikro-orm/mysql'
 import { captureException } from '@sentry/node'
 import { getMikroORM } from '../config/mikro-orm.config.js'
-import Integration, { IntegrationType } from '../entities/integration.js'
 import { SteamworksPlayerStat } from '../entities/steamworks-player-stat.js'
 import { streamByCursor } from '../lib/perf/streamByCursor.js'
 
@@ -19,34 +18,15 @@ export default async function cleanupSteamworksPlayerStats() {
       first: batchSize,
       after,
       orderBy: { id: 'asc' },
-      populate: ['stat.game'] as const,
+      populate: ['stat.game', 'integration'] as const,
     })
   }, 100)
 
-  const integrationsMap = new Map<number, Integration>()
   let processed = 0
 
   for await (const playerStat of playerStatStream) {
     try {
-      const game = playerStat.stat.game
-      let integration = integrationsMap.get(game.id)
-      if (!integration) {
-        try {
-          integration = await em
-            .repo(Integration)
-            .findOneOrFail({ game, type: IntegrationType.STEAMWORKS })
-        } catch (err) {
-          if (err instanceof NotFoundError) {
-            await em.repo(SteamworksPlayerStat).nativeDelete(playerStat.id)
-            continue
-          }
-          /* v8 ignore next -- @preserve */
-          throw err
-        }
-        integrationsMap.set(game.id, integration)
-      }
-
-      await integration.cleanupSteamworksPlayerStat(em, playerStat)
+      await playerStat.integration.cleanupSteamworksPlayerStat(em, playerStat)
       await new Promise((resolve) => setTimeout(resolve, 100))
     } catch (err) {
       console.error(

--- a/tests/lib/integrations/steamworksSyncLeaderboards.test.ts
+++ b/tests/lib/integrations/steamworksSyncLeaderboards.test.ts
@@ -160,15 +160,17 @@ describe('Steamworks integration - sync leaderboards', () => {
     const leaderboard = await new LeaderboardFactory([game])
       .state(() => ({ sortMode: LeaderboardSortMode.ASC }))
       .one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const config = await new IntegrationConfigFactory().one()
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([leaderboard, mapping, integration]).flush()
 
     const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
@@ -441,10 +443,6 @@ describe('Steamworks integration - sync leaderboards', () => {
     const [, game] = await createOrganisationAndGame()
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player]).one()
@@ -453,6 +451,12 @@ describe('Steamworks integration - sync leaderboards', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([leaderboard, mapping, player, entry, integration]).flush()
 
     const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
@@ -534,10 +538,6 @@ describe('Steamworks integration - sync leaderboards', () => {
     const [, game] = await createOrganisationAndGame()
 
     const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entries = await new LeaderboardEntryFactory(leaderboard, [player]).many(15)
@@ -546,6 +546,12 @@ describe('Steamworks integration - sync leaderboards', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([leaderboard, mapping, player, ...entries, integration]).flush()
 
     const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
@@ -722,10 +728,6 @@ describe('Steamworks integration - sync leaderboards', () => {
     const leaderboard = await new LeaderboardFactory([game])
       .state(() => ({ sortMode: LeaderboardSortMode.ASC }))
       .one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
       .state(() => ({ score: 10 }))
@@ -735,6 +737,12 @@ describe('Steamworks integration - sync leaderboards', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([leaderboard, mapping, integration, entry]).flush()
 
     const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
@@ -796,10 +804,6 @@ describe('Steamworks integration - sync leaderboards', () => {
     const [, game] = await createOrganisationAndGame()
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withUsernameAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player]).one()
@@ -808,6 +812,12 @@ describe('Steamworks integration - sync leaderboards', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([leaderboard, mapping, player, entry, integration]).flush()
 
     const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
@@ -874,5 +884,88 @@ describe('Steamworks integration - sync leaderboards', () => {
       .repo(SteamworksLeaderboardEntry)
       .findOne({ leaderboardEntry: entry }, { refresh: true })
     expect(steamworksEntry).toBeNull()
+  })
+
+  it('should create a mapping for a second integration without touching the first', async () => {
+    const [, game] = await createOrganisationAndGame()
+
+    const leaderboard = await new LeaderboardFactory([game]).one()
+
+    const configA = await new IntegrationConfigFactory().one()
+    const integrationA = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, configA)
+      .one()
+    const mappingA = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 111111,
+      leaderboard,
+      integration: integrationA,
+    })
+
+    const configB = await new IntegrationConfigFactory()
+      .state(() => ({ appId: configA.appId + 1 }))
+      .one()
+    const integrationB = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, configB)
+      .one()
+    await em.persist([leaderboard, integrationA, mappingA, integrationB]).flush()
+
+    const getLeaderboardsMock = vi.fn((): [number, GetLeaderboardsForGameResponse] => [
+      200,
+      {
+        response: {
+          result: 1,
+          leaderboards: [
+            {
+              id: 222222,
+              name: leaderboard.internalName,
+              entries: 0,
+              sortmethod: 'Descending',
+              displaytype: 'Numeric',
+              onlytrustedwrites: false,
+              onlyfriendsreads: false,
+            },
+          ],
+        },
+      },
+    ])
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamLeaderboards/GetLeaderboardsForGame/v2?appid=${integrationB.getSteamConfig().appId}`,
+      )
+      .replyOnce(getLeaderboardsMock)
+
+    const getEntriesMock = vi.fn((): [number, GetLeaderboardEntriesResponse] => [
+      200,
+      {
+        leaderboardEntryInformation: {
+          appID: 375290,
+          leaderboardID: 222222,
+          totalLeaderBoardEntryCount: 0,
+          leaderboardEntries: [],
+        },
+      },
+    ])
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamLeaderboards/GetLeaderboardEntries/v1?appid=${integrationB.getSteamConfig().appId}&leaderboardid=222222&rangestart=0&rangeend=1.7976931348623157e%2B308&datarequest=RequestGlobal`,
+      )
+      .replyOnce(getEntriesMock)
+
+    await syncSteamworksLeaderboards(em, integrationB)
+
+    // integration B got its own mapping for the same talo leaderboard
+    const mappingB = await em.repo(SteamworksLeaderboardMapping).findOne({
+      leaderboard,
+      integration: integrationB,
+      steamworksLeaderboardId: 222222,
+    })
+    expect(mappingB).toBeTruthy()
+
+    // integration A's mapping is untouched
+    const unchangedMappingA = await em.repo(SteamworksLeaderboardMapping).findOneOrFail({
+      leaderboard,
+      integration: integrationA,
+    })
+    expect(unchangedMappingA.steamworksLeaderboardId).toBe(111111)
   })
 })

--- a/tests/lib/integrations/triggerIntegrations.test.ts
+++ b/tests/lib/integrations/triggerIntegrations.test.ts
@@ -1,0 +1,31 @@
+import { IntegrationType } from '../../../src/entities/integration.js'
+import triggerIntegrations from '../../../src/lib/integrations/triggerIntegrations.js'
+import IntegrationConfigFactory from '../../fixtures/IntegrationConfigFactory.js'
+import IntegrationFactory from '../../fixtures/IntegrationFactory.js'
+import createOrganisationAndGame from '../../utils/createOrganisationAndGame.js'
+
+describe('triggerIntegrations', () => {
+  it('should run every integration even when one throws', async () => {
+    const [, game] = await createOrganisationAndGame()
+
+    const first = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, await new IntegrationConfigFactory().one())
+      .one()
+    const second = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, await new IntegrationConfigFactory().one())
+      .one()
+    await em.persist([first, second]).flush()
+
+    const calls: number[] = []
+    await expect(
+      triggerIntegrations(em, game, async (integration) => {
+        if (integration.id === first.id) {
+          throw new Error('first integration failed')
+        }
+        calls.push(integration.id)
+      }),
+    ).resolves.not.toThrow()
+
+    expect(calls).toStrictEqual([second.id])
+  })
+})

--- a/tests/routes/api/game-stat/steamworks-put.test.ts
+++ b/tests/routes/api/game-stat/steamworks-put.test.ts
@@ -4,6 +4,7 @@ import request from 'supertest'
 import { APIKeyScope } from '../../../../src/entities/api-key.js'
 import { IntegrationType } from '../../../../src/entities/integration.js'
 import SteamworksIntegrationEvent from '../../../../src/entities/steamworks-integration-event.js'
+import { SteamworksPlayerStat } from '../../../../src/entities/steamworks-player-stat.js'
 import GameStatFactory from '../../../fixtures/GameStatFactory.js'
 import IntegrationConfigFactory from '../../../fixtures/IntegrationConfigFactory.js'
 import IntegrationFactory from '../../../fixtures/IntegrationFactory.js'
@@ -13,7 +14,7 @@ import createAPIKeyAndToken from '../../../utils/createAPIKeyAndToken.js'
 describe('Game stat API - steamworks update', () => {
   const axiosMock = new AxiosMockAdapter(axios)
 
-  afterAll(async () => {
+  afterEach(async () => {
     axiosMock.reset()
   })
 
@@ -97,5 +98,60 @@ describe('Game stat API - steamworks update', () => {
 
     const event = await em.repo(SteamworksIntegrationEvent).findOne({ integration })
     expect(event).toBeNull()
+  })
+
+  it('should set a player stat in steamworks for every integration', async () => {
+    const setMock = vi.fn(() => [
+      200,
+      {
+        result: {
+          result: 1,
+        },
+      },
+    ])
+    axiosMock
+      .onPost('https://partner.steam-api.com/ISteamUserStats/SetUserStatsForGame/v1')
+      .reply(setMock)
+
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.WRITE_GAME_STATS])
+
+    const stat = await new GameStatFactory([apiKey.game])
+      .state(() => ({ maxChange: 99, maxValue: 3000 }))
+      .one()
+    const player = await new PlayerFactory([apiKey.game]).withSteamAlias().one()
+
+    const configA = await new IntegrationConfigFactory().state(() => ({ syncStats: true })).one()
+    const integrationA = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, configA)
+      .one()
+    const configB = await new IntegrationConfigFactory()
+      .state(() => ({ syncStats: true, appId: configA.appId + 1 }))
+      .one()
+    const integrationB = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, configB)
+      .one()
+    await em.persist([integrationA, integrationB, stat, player]).flush()
+
+    await request(app)
+      .put(`/v1/game-stats/${stat.internalName}`)
+      .send({ change: 10 })
+      .auth(token, { type: 'bearer' })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .expect(200)
+
+    expect(setMock).toHaveBeenCalledTimes(2)
+
+    // one tracked row per integration
+    expect(await em.repo(SteamworksPlayerStat).count({ integration: integrationA })).toBe(1)
+    expect(await em.repo(SteamworksPlayerStat).count({ integration: integrationB })).toBe(1)
+
+    const eventA = await em
+      .repo(SteamworksIntegrationEvent)
+      .findOneOrFail({ integration: integrationA })
+    expect(eventA.request.body).toContain(`appid=${configA.appId}`)
+    const eventB = await em
+      .repo(SteamworksIntegrationEvent)
+      .findOneOrFail({ integration: integrationB })
+    expect(eventB.request.body).toContain(`appid=${configB.appId}`)
   })
 })

--- a/tests/routes/api/leaderboard/steamworks-post.test.ts
+++ b/tests/routes/api/leaderboard/steamworks-post.test.ts
@@ -36,10 +36,6 @@ describe('Leaderboard API - steamworks create', () => {
     const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.WRITE_LEADERBOARDS])
 
     const leaderboard = await new LeaderboardFactory([apiKey.game]).notUnique().one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
     const player = await new PlayerFactory([apiKey.game]).withSteamAlias().one()
 
     const config = await new IntegrationConfigFactory()
@@ -48,6 +44,12 @@ describe('Leaderboard API - steamworks create', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, apiKey.game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([integration, leaderboard, player, mapping]).flush()
 
     await request(app)
@@ -70,6 +72,69 @@ describe('Leaderboard API - steamworks create', () => {
       .repo(SteamworksLeaderboardEntry)
       .findOne({ steamworksLeaderboard: mapping })
     expect(steamworksEntry).toBeTruthy()
+  })
+
+  it('should create a leaderboard entry in steamworks for every integration', async () => {
+    const createMock = vi.fn(() => [
+      200,
+      {
+        result: {
+          result: 1,
+        },
+      },
+    ])
+    axiosMock
+      .onPost('https://partner.steam-api.com/ISteamLeaderboards/SetLeaderboardScore/v1')
+      .reply(createMock)
+
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.WRITE_LEADERBOARDS])
+
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).notUnique().one()
+    const player = await new PlayerFactory([apiKey.game]).withSteamAlias().one()
+
+    const integrations = []
+    const mappings = []
+    for (let i = 0; i < 2; i++) {
+      const config = await new IntegrationConfigFactory()
+        .state(() => ({ syncLeaderboards: true }))
+        .one()
+      const integration = await new IntegrationFactory()
+        .construct(IntegrationType.STEAMWORKS, apiKey.game, config)
+        .one()
+      integrations.push(integration)
+      mappings.push(
+        new SteamworksLeaderboardMapping({
+          steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+          leaderboard,
+          integration,
+        }),
+      )
+    }
+
+    await em.persist([...integrations, leaderboard, player, ...mappings]).flush()
+
+    await request(app)
+      .post(`/v1/leaderboards/${leaderboard.internalName}/entries`)
+      .send({ score: 300 })
+      .auth(token, { type: 'bearer' })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .expect(200)
+
+    expect(createMock).toHaveBeenCalledTimes(2)
+    for (const mapping of mappings) {
+      expect(createMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.stringContaining(`leaderboardid=${mapping.steamworksLeaderboardId}`),
+        }),
+      )
+
+      const steamworksEntry = await em
+        .repo(SteamworksLeaderboardEntry)
+        .findOne({ steamworksLeaderboard: mapping })
+      expect(steamworksEntry).toBeTruthy()
+    }
+
+    axiosMock.reset()
   })
 
   it('should not create a leaderboard entry in steamworks if there is no mapping', async () => {

--- a/tests/routes/api/player/steamworks-identify.test.ts
+++ b/tests/routes/api/player/steamworks-identify.test.ts
@@ -143,6 +143,164 @@ describe('Player API - Steamworks identify', () => {
     )
   })
 
+  it('should identify a steamworks player with multiple integrations of the same type', async () => {
+    const appId = randNumber({ min: 1000, max: 1_000_000 })
+    const otherAppId = appId + 1
+    const steamId = randNumber({ min: 100_000, max: 1_000_000 }).toString()
+    const ticket = '000validticket'
+    const identity = 'talo'
+
+    // the ticket only validates against the matching integration's app
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1?appid=${otherAppId}&ticket=${ticket}&identity=${identity}`,
+      )
+      .reply(400, {
+        response: { error: { errorcode: 3, errordesc: 'Bad Request' } },
+      })
+
+    const authenticateTicketMock = vi.fn(() => [
+      200,
+      {
+        response: {
+          params: {
+            steamid: steamId,
+            ownersteamid: steamId,
+            vacbanned: false,
+            publisherbanned: false,
+          },
+        },
+      },
+    ])
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1?appid=${appId}&ticket=${ticket}&identity=${identity}`,
+      )
+      .reply(authenticateTicketMock)
+
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamUser/CheckAppOwnership/v3?appid=${appId}&steamid=${steamId}`,
+      )
+      .reply(() => [
+        200,
+        {
+          appownership: {
+            appid: appId,
+            ownsapp: true,
+            permanent: true,
+            timestamp: '2021-08-01T00:00:00.000Z',
+            ownersteamid: steamId,
+            usercanceled: false,
+          },
+        },
+      ])
+
+    axiosMock
+      .onGet(`https://partner.steam-api.com/ISteamUser/GetPlayerSummaries/v2?steamids=${steamId}`)
+      .reply(() => [
+        200,
+        {
+          response: {
+            players: [
+              {
+                steamid: steamId,
+                personaname: 'TestPlayer',
+                avatarhash: 'abcd1234',
+              },
+            ],
+          },
+        },
+      ])
+
+    const [apiKey, token] = await createAPIKeyAndToken([
+      APIKeyScope.READ_PLAYERS,
+      APIKeyScope.WRITE_PLAYERS,
+    ])
+
+    const otherConfig = await new IntegrationConfigFactory()
+      .state(() => ({ appId: otherAppId }))
+      .one()
+    const otherIntegration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, otherConfig)
+      .one()
+    const config = await new IntegrationConfigFactory().state(() => ({ appId })).one()
+    const integration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, config)
+      .one()
+    await em.persist([otherIntegration, integration]).flush()
+
+    const res = await request(app)
+      .get('/v1/players/identify')
+      .query({ service: PlayerAliasService.STEAM, identifier: `${identity}:${ticket}` })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(authenticateTicketMock).toHaveBeenCalledOnce()
+    expect(res.body.alias.identifier).toBe(steamId)
+    expect(res.body.alias.player.props).toEqual(
+      expect.arrayContaining([{ key: 'META_STEAMWORKS_OWNS_APP', value: 'true' }]),
+    )
+  })
+
+  it('should return the last error when all integrations fail to authenticate the ticket', async () => {
+    const appId = randNumber({ min: 1000, max: 1_000_000 })
+    const otherAppId = appId + 1
+    const ticket = '000invalidticket'
+    const identity = 'talo'
+
+    const authenticateTicketMock = vi.fn(() => [
+      200,
+      {
+        response: { error: { errorcode: 101, errordesc: 'Invalid ticket' } },
+      },
+    ])
+    const otherAuthenticateTicketMock = vi.fn(() => [
+      200,
+      {
+        response: { error: { errorcode: 102, errordesc: 'Expired ticket' } },
+      },
+    ])
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1?appid=${appId}&ticket=${ticket}&identity=${identity}`,
+      )
+      .reply(authenticateTicketMock)
+    axiosMock
+      .onGet(
+        `https://partner.steam-api.com/ISteamUserAuth/AuthenticateUserTicket/v1?appid=${otherAppId}&ticket=${ticket}&identity=${identity}`,
+      )
+      .reply(otherAuthenticateTicketMock)
+
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_PLAYERS])
+
+    const config = await new IntegrationConfigFactory().state(() => ({ appId })).one()
+    const integration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, config)
+      .one()
+    const otherConfig = await new IntegrationConfigFactory()
+      .state(() => ({ appId: otherAppId }))
+      .one()
+    const otherIntegration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, apiKey.game, otherConfig)
+      .one()
+    await em.persist([integration, otherIntegration]).flush()
+
+    const res = await request(app)
+      .get('/v1/players/identify')
+      .query({ service: PlayerAliasService.STEAM, identifier: `${identity}:${ticket}` })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+
+    expect(authenticateTicketMock).toHaveBeenCalledOnce()
+    expect(otherAuthenticateTicketMock).toHaveBeenCalledOnce()
+
+    // the last integration's error is what surfaces
+    expect(res.body).toStrictEqual({
+      message: 'Failed to authenticate Steamworks ticket: Expired ticket (102)',
+    })
+  })
+
   it('should identify a non-existent steamworks player by creating a new player with the write scope', async () => {
     const appId = randNumber({ min: 1000, max: 1_000_000 })
     const steamId = randNumber({ min: 100_000, max: 1_000_000 }).toString()

--- a/tests/routes/protected/integration/create.test.ts
+++ b/tests/routes/protected/integration/create.test.ts
@@ -101,7 +101,30 @@ describe('Integration - create', () => {
     expect(activity).toBe(null)
   })
 
-  it('should not add a duplicate integration for the same type', async () => {
+  it('should allow multiple integrations of the same type', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({ type: UserType.ADMIN }, organisation)
+
+    const config = await new IntegrationConfigFactory().one()
+    const integration = new Integration(IntegrationType.STEAMWORKS, game, config)
+    await em.persist(integration).flush()
+
+    const res = await request(app)
+      .post(`/games/${game.id}/integrations`)
+      .send({
+        type: IntegrationType.STEAMWORKS,
+        config: { ...config, appId: config.appId + 1 },
+      })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.integration.id).not.toBe(integration.id)
+
+    const count = await em.repo(Integration).count({ game, type: IntegrationType.STEAMWORKS })
+    expect(count).toBe(2)
+  })
+
+  it('should not add an integration for the same external app', async () => {
     const [organisation, game] = await createOrganisationAndGame()
     const [token] = await createUserAndToken({ type: UserType.ADMIN }, organisation)
 
@@ -116,7 +139,7 @@ describe('Integration - create', () => {
       .expect(400)
 
     expect(res.body).toStrictEqual({
-      message: `This game already has an integration for ${IntegrationType.STEAMWORKS}`,
+      message: `This game already has an integration for ${IntegrationType.STEAMWORKS} with this appId`,
     })
   })
 

--- a/tests/routes/protected/integration/delete.test.ts
+++ b/tests/routes/protected/integration/delete.test.ts
@@ -1,10 +1,16 @@
 import request from 'supertest'
 import GameActivity, { GameActivityType } from '../../../../src/entities/game-activity.js'
-import { IntegrationType } from '../../../../src/entities/integration.js'
+import Integration, { IntegrationType } from '../../../../src/entities/integration.js'
 import SteamworksIntegrationEvent from '../../../../src/entities/steamworks-integration-event.js'
+import { SteamworksLeaderboardEntry } from '../../../../src/entities/steamworks-leaderboard-entry.js'
+import SteamworksLeaderboardMapping from '../../../../src/entities/steamworks-leaderboard-mapping.js'
+import { SteamworksPlayerStat } from '../../../../src/entities/steamworks-player-stat.js'
 import { UserType } from '../../../../src/entities/user.js'
+import GameStatFactory from '../../../fixtures/GameStatFactory.js'
 import IntegrationConfigFactory from '../../../fixtures/IntegrationConfigFactory.js'
 import IntegrationFactory from '../../../fixtures/IntegrationFactory.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
 import createOrganisationAndGame from '../../../utils/createOrganisationAndGame.js'
 import createUserAndToken from '../../../utils/createUserAndToken.js'
 import userPermissionProvider from '../../../utils/userPermissionProvider.js'
@@ -100,5 +106,50 @@ describe('Integration - delete', () => {
     expect(res.body).toStrictEqual({ message: 'Integration not found' })
 
     expect(activity).toBeNull()
+  })
+
+  it('should delete steamworks entities when deleting an integration', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({ type: UserType.ADMIN }, organisation)
+
+    const config = await new IntegrationConfigFactory().one()
+    const integration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, config)
+      .one()
+
+    const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 12345,
+      leaderboard,
+      integration,
+    })
+    const player = await new PlayerFactory([game]).withSteamAlias().one()
+    const steamworksEntry = new SteamworksLeaderboardEntry({
+      steamworksLeaderboard: mapping,
+      leaderboardEntry: null,
+      steamUserId: player.aliases[0].identifier,
+    })
+    const steamworksPlayerStat = new SteamworksPlayerStat({
+      stat: await new GameStatFactory([game]).one(),
+      integration,
+      playerStat: null,
+      steamUserId: player.aliases[0].identifier,
+    })
+
+    await em
+      .persist([integration, leaderboard, player, mapping, steamworksEntry, steamworksPlayerStat])
+      .flush()
+
+    await request(app)
+      .delete(`/games/${game.id}/integrations/${integration.id}`)
+      .auth(token, { type: 'bearer' })
+      .expect(204)
+
+    expect(await em.repo(Integration).count({ game })).toBe(0)
+    expect(await em.repo(SteamworksLeaderboardMapping).count({ leaderboard })).toBe(0)
+    expect(
+      await em.repo(SteamworksLeaderboardEntry).count({ steamworksLeaderboard: { leaderboard } }),
+    ).toBe(0)
+    expect(await em.repo(SteamworksPlayerStat).count({ stat: steamworksPlayerStat.stat })).toBe(0)
   })
 })

--- a/tests/routes/protected/integration/update.test.ts
+++ b/tests/routes/protected/integration/update.test.ts
@@ -205,4 +205,36 @@ describe('Integration - update', () => {
 
     expect(activity).toBeNull()
   })
+
+  it('should not update an integration to the same external app as another integration', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({ type: UserType.ADMIN }, organisation)
+
+    const config = await new IntegrationConfigFactory().one()
+    const integration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, config)
+      .one()
+    const otherConfig = await new IntegrationConfigFactory()
+      .state(() => ({ appId: config.appId + 1 }))
+      .one()
+    const otherIntegration = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, otherConfig)
+      .one()
+    await em.persist([integration, otherIntegration]).flush()
+    await em.refresh(integration)
+
+    const res = await request(app)
+      .patch(`/games/${game.id}/integrations/${integration.id}`)
+      .send({ config: { appId: otherConfig.appId } })
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+
+    expect(res.body).toStrictEqual({
+      message: `This game already has an integration for ${IntegrationType.STEAMWORKS} with this appId`,
+    })
+
+    // the conflicting update must not have been applied
+    await em.refresh(integration)
+    expect(integration.getSteamConfig().appId).toBe(config.appId)
+  })
 })

--- a/tests/routes/protected/leaderboard/steamworks-delete.test.ts
+++ b/tests/routes/protected/leaderboard/steamworks-delete.test.ts
@@ -95,7 +95,6 @@ describe('Leaderboard - steamworks delete', () => {
       .replyOnce(deleteMock)
 
     const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
-    const steamworksLeaderboard = new SteamworksLeaderboardMapping(12345, leaderboard)
 
     const config = await new IntegrationConfigFactory()
       .state(() => ({ syncLeaderboards: true }))
@@ -103,6 +102,11 @@ describe('Leaderboard - steamworks delete', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const steamworksLeaderboard = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 12345,
+      leaderboard,
+      integration,
+    })
 
     const players = await new PlayerFactory([game]).many(10)
     const entries = await Promise.all(

--- a/tests/routes/protected/leaderboard/steamworks-update-entry.test.ts
+++ b/tests/routes/protected/leaderboard/steamworks-update-entry.test.ts
@@ -39,18 +39,9 @@ describe('Leaderboard - steamworks update entry', () => {
       .replyOnce(updateMock)
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player]).one()
-    const steamworksEntry = new SteamworksLeaderboardEntry({
-      steamworksLeaderboard: mapping,
-      leaderboardEntry: entry,
-      steamUserId: player.aliases[0].identifier,
-    })
 
     const config = await new IntegrationConfigFactory()
       .state(() => ({ syncLeaderboards: true }))
@@ -58,6 +49,17 @@ describe('Leaderboard - steamworks update entry', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+    const steamworksEntry = new SteamworksLeaderboardEntry({
+      steamworksLeaderboard: mapping,
+      leaderboardEntry: entry,
+      steamUserId: player.aliases[0].identifier,
+    })
+
     await em.persist([integration, steamworksEntry]).flush()
 
     await request(app)
@@ -99,10 +101,6 @@ describe('Leaderboard - steamworks update entry', () => {
       .replyOnce(updateMock)
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
@@ -115,6 +113,12 @@ describe('Leaderboard - steamworks update entry', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([integration, entry, mapping]).flush()
 
     await request(app)
@@ -143,10 +147,6 @@ describe('Leaderboard - steamworks update entry', () => {
       .replyOnce(updateMock)
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
@@ -159,6 +159,12 @@ describe('Leaderboard - steamworks update entry', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([integration, entry, mapping]).flush()
 
     await request(app)
@@ -180,10 +186,6 @@ describe('Leaderboard - steamworks update entry', () => {
       .replyOnce(updateMock)
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withUsernameAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
@@ -196,6 +198,12 @@ describe('Leaderboard - steamworks update entry', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([integration, entry, mapping]).flush()
 
     await request(app)
@@ -261,10 +269,6 @@ describe('Leaderboard - steamworks update entry', () => {
       .replyOnce(updateMock)
 
     const leaderboard = await new LeaderboardFactory([game]).one()
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
 
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const entry = await new LeaderboardEntryFactory(leaderboard, [player])
@@ -277,6 +281,12 @@ describe('Leaderboard - steamworks update entry', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
+
     await em.persist([integration, entry, mapping]).flush()
 
     await request(app)

--- a/tests/tasks/archiveLeaderboardEntries.test.ts
+++ b/tests/tasks/archiveLeaderboardEntries.test.ts
@@ -152,11 +152,6 @@ describe('archiveLeaderboardEntries', () => {
       .onPost('https://partner.steam-api.com/ISteamLeaderboards/DeleteLeaderboardScore/v1')
       .reply(deleteMock)
 
-    const mapping = new SteamworksLeaderboardMapping(
-      randNumber({ min: 100_000, max: 999_999 }),
-      leaderboard,
-    )
-
     const player = await new PlayerFactory([game]).withSteamAlias().one()
     const oldEntry = await new LeaderboardEntryFactory(leaderboard, [player])
       .state(() => ({ createdAt: sub(new Date(), { days: 2 }) }))
@@ -168,6 +163,11 @@ describe('archiveLeaderboardEntries', () => {
     const integration = await new IntegrationFactory()
       .construct(IntegrationType.STEAMWORKS, game, config)
       .one()
+    const mapping = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: randNumber({ min: 100_000, max: 999_999 }),
+      leaderboard,
+      integration,
+    })
 
     await em.persist([integration, oldEntry, mapping]).flush()
     await archiveLeaderboardEntries()

--- a/tests/tasks/cleanupSteamworksLeaderboardEntries.test.ts
+++ b/tests/tasks/cleanupSteamworksLeaderboardEntries.test.ts
@@ -50,7 +50,11 @@ describe('cleanupSteamworksLeaderboardEntries', () => {
       .one()
 
     const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
-    const steamworksLeaderboard = new SteamworksLeaderboardMapping(12345, leaderboard)
+    const steamworksLeaderboard = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 12345,
+      leaderboard,
+      integration,
+    })
 
     const players = await new PlayerFactory([game]).many(10)
     const entries = await Promise.all(
@@ -96,7 +100,11 @@ describe('cleanupSteamworksLeaderboardEntries', () => {
       .one()
 
     const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
-    const steamworksLeaderboard = new SteamworksLeaderboardMapping(12345, leaderboard)
+    const steamworksLeaderboard = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 12345,
+      leaderboard,
+      integration,
+    })
 
     const players = await new PlayerFactory([game]).many(5)
     const entries = players.map((player) => {
@@ -121,30 +129,52 @@ describe('cleanupSteamworksLeaderboardEntries', () => {
     expect(entryCount).toBe(1)
   })
 
-  it('should still delete steamworks leaderboard entries for games without integrations', async () => {
+  it('should cleanup leaderboard entries via their own integration', async () => {
     const [, game] = await createOrganisationAndGame()
+    const integrationA = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, await new IntegrationConfigFactory().one())
+      .one()
+    const configA = integrationA.getSteamConfig()
+    const integrationB = await new IntegrationFactory()
+      .construct(
+        IntegrationType.STEAMWORKS,
+        game,
+        await new IntegrationConfigFactory().state(() => ({ appId: configA.appId! + 1 })).one(),
+      )
+      .one()
 
     const leaderboard = await new LeaderboardFactory([game]).state(() => ({ unique: false })).one()
-    const steamworksLeaderboard = new SteamworksLeaderboardMapping(12345, leaderboard)
+    const mappingA = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 12345,
+      leaderboard,
+      integration: integrationA,
+    })
+    const mappingB = new SteamworksLeaderboardMapping({
+      steamworksLeaderboardId: 54321,
+      leaderboard,
+      integration: integrationB,
+    })
 
-    const players = await new PlayerFactory([game]).many(5)
-    const entries = await Promise.all(
-      players.map(async (player) => {
-        return new SteamworksLeaderboardEntry({
-          steamworksLeaderboard,
-          leaderboardEntry: null,
-          steamUserId: player.aliases[0].identifier,
-        })
-      }),
-    )
-    await em.persist(entries).flush()
+    const [playerA, playerB] = await new PlayerFactory([game]).many(2)
+    const entryA = new SteamworksLeaderboardEntry({
+      steamworksLeaderboard: mappingA,
+      leaderboardEntry: null,
+      steamUserId: playerA.aliases[0].identifier,
+    })
+    const entryB = new SteamworksLeaderboardEntry({
+      steamworksLeaderboard: mappingB,
+      leaderboardEntry: null,
+      steamUserId: playerB.aliases[0].identifier,
+    })
+
+    await em.persist([integrationA, integrationB, mappingA, mappingB, entryA, entryB]).flush()
 
     await cleanupSteamworksLeaderboardEntries()
 
-    expect(deleteMock).toHaveBeenCalledTimes(0)
+    expect(deleteMock).toHaveBeenCalledTimes(2)
 
-    const eventCount = await em.repo(SteamworksIntegrationEvent).count({ integration: { game } })
-    expect(eventCount).toBe(0)
+    expect(await em.repo(SteamworksIntegrationEvent).count({ integration: integrationA })).toBe(1)
+    expect(await em.repo(SteamworksIntegrationEvent).count({ integration: integrationB })).toBe(1)
 
     const entryCount = await em.repo(SteamworksLeaderboardEntry).count()
     expect(entryCount).toBe(0)

--- a/tests/tasks/cleanupSteamworksPlayerStats.test.ts
+++ b/tests/tasks/cleanupSteamworksPlayerStats.test.ts
@@ -50,6 +50,7 @@ describe('cleanupSteamworksPlayerStats', () => {
       players.map(async (player) => {
         return new SteamworksPlayerStat({
           stat,
+          integration,
           playerStat: await new PlayerGameStatFactory().construct(player, stat).one(),
           steamUserId: player.aliases[0].identifier,
         })
@@ -90,6 +91,7 @@ describe('cleanupSteamworksPlayerStats', () => {
     const playerStats = players.map((player) => {
       return new SteamworksPlayerStat({
         stat,
+        integration,
         playerStat: null,
         steamUserId: player.aliases[0].identifier,
       })
@@ -109,33 +111,6 @@ describe('cleanupSteamworksPlayerStats', () => {
     expect(playerStatCount).toBe(1)
   })
 
-  it('should still delete steamworks player stats for games without integrations', async () => {
-    const [, game] = await createOrganisationAndGame()
-
-    const stat = await new GameStatFactory([game]).one()
-    const players = await new PlayerFactory([game]).withSteamAlias().many(5)
-
-    const playerStats = players.map((player) => {
-      return new SteamworksPlayerStat({
-        stat,
-        playerStat: null,
-        steamUserId: player.aliases[0].identifier,
-      })
-    })
-
-    await em.persist(playerStats).flush()
-
-    await cleanupSteamworksPlayerStats()
-
-    expect(setMock).toHaveBeenCalledTimes(0)
-
-    const eventCount = await em.repo(SteamworksIntegrationEvent).count({ integration: { game } })
-    expect(eventCount).toBe(0)
-
-    const playerStatCount = await em.repo(SteamworksPlayerStat).count()
-    expect(playerStatCount).toBe(0)
-  })
-
   it('should set stats to default values when cleaning up', async () => {
     const [, game] = await createOrganisationAndGame()
     const config = await new IntegrationConfigFactory().one()
@@ -148,6 +123,7 @@ describe('cleanupSteamworksPlayerStats', () => {
 
     const playerStat = new SteamworksPlayerStat({
       stat,
+      integration,
       playerStat: null,
       steamUserId: player.aliases[0].identifier,
     })
@@ -181,6 +157,7 @@ describe('cleanupSteamworksPlayerStats', () => {
       players.map(async (player) => {
         return new SteamworksPlayerStat({
           stat,
+          integration,
           playerStat: await new PlayerGameStatFactory().construct(player, stat).one(),
           steamUserId: player.aliases[0].identifier,
         })
@@ -201,5 +178,54 @@ describe('cleanupSteamworksPlayerStats', () => {
 
     const playerStatCount = await em.repo(SteamworksPlayerStat).count()
     expect(playerStatCount).toBe(3)
+  })
+
+  it('should cleanup player stats via their own integration', async () => {
+    const [, game] = await createOrganisationAndGame()
+    const configA = await new IntegrationConfigFactory().one()
+    const integrationA = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, configA)
+      .one()
+    const configB = await new IntegrationConfigFactory()
+      .state(() => ({ appId: configA.appId + 1 }))
+      .one()
+    const integrationB = await new IntegrationFactory()
+      .construct(IntegrationType.STEAMWORKS, game, configB)
+      .one()
+
+    const stat = await new GameStatFactory([game]).one()
+    const [playerA, playerB] = await new PlayerFactory([game]).withSteamAlias().many(2)
+
+    const statA = new SteamworksPlayerStat({
+      stat,
+      integration: integrationA,
+      playerStat: null,
+      steamUserId: playerA.aliases[0].identifier,
+    })
+    const statB = new SteamworksPlayerStat({
+      stat,
+      integration: integrationB,
+      playerStat: null,
+      steamUserId: playerB.aliases[0].identifier,
+    })
+
+    await em.persist([integrationA, integrationB, statA, statB]).flush()
+
+    await cleanupSteamworksPlayerStats()
+
+    expect(setMock).toHaveBeenCalledTimes(2)
+
+    expect(await em.repo(SteamworksIntegrationEvent).count({ integration: integrationA })).toBe(1)
+    expect(await em.repo(SteamworksIntegrationEvent).count({ integration: integrationB })).toBe(1)
+
+    // each row was reset against its own integration's app
+    const events = await em.repo(SteamworksIntegrationEvent).findAll()
+    const bodies = events.map((event) => event.request.body)
+    expect(bodies).toContain(
+      `appid=${configA.appId}&steamid=${playerA.aliases[0].identifier}&count=1&name%5B0%5D=${stat.internalName}&value%5B0%5D=${stat.defaultValue}`,
+    )
+    expect(bodies).toContain(
+      `appid=${configB.appId}&steamid=${playerB.aliases[0].identifier}&count=1&name%5B0%5D=${stat.internalName}&value%5B0%5D=${stat.defaultValue}`,
+    )
   })
 })


### PR DESCRIPTION
**Entity model**
- `SteamworksLeaderboardMapping` composite primary key now includes `integration_id`, so the same Talo leaderboard can map to different Steamworks leaderboards across integrations.
- `SteamworksLeaderboardEntry` FK and unique constraint widened to include `integration_id`.
- `SteamworksPlayerStat` gains an `integration` FK with a unique constraint on `(integration_id, player_stat_id)` replacing the old `player_stat_id` unique.
- Two migrations backfill `integration_id` from the game's existing Steamworks integration, then enforce NOT NULL.

**Duplicate detection**
- Creating or updating an integration now checks whether another integration of the same type already points at the same external app identity (`appId`, `clientId`, or `bundleId`).
- Different apps of the same type are allowed; same app is rejected with a descriptive error.

**Player resolution**
- `PlayerAlias.resolveIdentifier` loads all integrations of the matching type (newest first) and tries each until one succeeds, so a ticket valid against one app is accepted even when other integrations exist.
- `Integration.getPlayerIdentifier` now returns a uniform `{ identifier, initialPlayerProps }` shape instead of a union of per-service result types.

**Integration triggering**
- `triggerIntegrations` runs integrations sequentially instead of `Promise.all` and catches per-integration errors, so one failing integration no longer blocks the rest.

**Cleanup tasks**
- `cleanupSteamworksLeaderboardEntries` and `cleanupSteamworksPlayerStats` populate and follow the direct `integration` relation instead of resolving it through game lookups, simplifying the logic and removing orphan-handling fallbacks.