### PR TITLE
Enable ClickHouse progress headers for long queries

### DIFF
--- a/src/lib/clickhouse/createClient.ts
+++ b/src/lib/clickhouse/createClient.ts
@@ -137,6 +137,10 @@ export default function createTracedClickHouseClient(options: CreateClickHouseCl
   const client = createClient({
     url,
     request_timeout: 120_000,
+    clickhouse_settings: {
+      send_progress_in_http_headers: 1,
+      http_headers_progress_interval_ms: '10000',
+    },
   })
 
   return new Proxy(client, createClickHouseTracingProxyHandler())


### PR DESCRIPTION
**Long query visibility**
- Enable `send_progress_in_http_headers` on the ClickHouse client so long-running queries report progress in HTTP headers
- Set the progress interval to 10 seconds via `http_headers_progress_interval_ms` to avoid excessive header noise