### PR TITLE
Add optional body response to health check endpoints

### DIFF
--- a/src/routes/api/health-check/index.ts
+++ b/src/routes/api/health-check/index.ts
@@ -7,7 +7,14 @@ export function healthCheckAPIRouter(router: Router) {
     ({ route }) => {
       route({
         method: 'get',
-        handler: () => {
+        handler: (ctx) => {
+          if (ctx.query.body === '1') {
+            return {
+              status: 200,
+              body: 'OK',
+            }
+          }
+
           return {
             status: 204,
           }

--- a/src/routes/public/health-check/index.ts
+++ b/src/routes/public/health-check/index.ts
@@ -7,7 +7,14 @@ export function healthCheckRouter(router: Router) {
     ({ route }) => {
       route({
         method: 'get',
-        handler: () => {
+        handler: (ctx) => {
+          if (ctx.query.body === '1') {
+            return {
+              status: 200,
+              body: 'OK',
+            }
+          }
+
           return {
             status: 204,
           }

--- a/tests/routes/api/health-check/get.test.ts
+++ b/tests/routes/api/health-check/get.test.ts
@@ -7,4 +7,13 @@ describe('Health check API - get', () => {
 
     await request(app).get('/v1/health-check').auth(token, { type: 'bearer' }).expect(204)
   })
+
+  it('should return a 200 with a body if body=1', async () => {
+    const [, token] = await createAPIKeyAndToken([])
+
+    const res = await request(app).get('/v1/health-check?body=1').auth(token, { type: 'bearer' })
+
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('OK')
+  })
 })

--- a/tests/routes/public/health-check/get.test.ts
+++ b/tests/routes/public/health-check/get.test.ts
@@ -4,4 +4,11 @@ describe('Health check - get', () => {
   it('should return a 204', async () => {
     await request(app).get('/public/health').expect(204)
   })
+
+  it('should return a 200 with a body if body=1', async () => {
+    const res = await request(app).get('/public/health?body=1')
+
+    expect(res.status).toBe(200)
+    expect(res.text).toBe('OK')
+  })
 })


### PR DESCRIPTION
## Problem

- Health check endpoints return 204 No Content by default, which some load balancers and monitoring tools interpret as unhealthy

## Solution

- Support `?body=1` query parameter on both API and public health check endpoints
- When present, return HTTP 200 with a plain text `OK` body instead of 204
- Default behavior without the parameter is unchanged