### PR TITLE
Add leaderboard top entries endpoint with optimized indexes

### DIFF
--- a/src/entities/leaderboard-entry.ts
+++ b/src/entities/leaderboard-entry.ts
@@ -5,15 +5,23 @@ import LeaderboardEntryProp from './leaderboard-entry-prop.js'
 import Leaderboard from './leaderboard.js'
 import PlayerAlias from './player-alias.js'
 
-const scoreIndexName = 'idx_leaderboardentry_hidden_leaderboard_id_score'
-const scoreIndexExpr = `alter table \`leaderboard_entry\` add index \`${scoreIndexName}\`(\`hidden\`, \`leaderboard_id\`, \`score\`)`
+// asc leaderboard entry ordering
+// deleted_at sits in the prefix so soft-deleted rows never get scanned
+const ascOrderIndexName = 'idx_leaderboardentry_order_asc'
+const ascOrderIndexExpr = `alter table \`leaderboard_entry\` add index \`${ascOrderIndexName}\`(\`leaderboard_id\`, \`hidden\`, \`deleted_at\`, \`score\`, \`created_at\`, \`id\`)`
+
+// desc leaderboard entry ordering - a reverse scan of the asc index would also reverse
+// the createdAt/id tie-breaks, so score needs an explicit descending index part
+const descOrderIndexName = 'idx_leaderboardentry_order_desc'
+const descOrderIndexExpr = `alter table \`leaderboard_entry\` add index \`${descOrderIndexName}\`(\`leaderboard_id\`, \`hidden\`, \`deleted_at\`, \`score\` desc, \`created_at\`, \`id\`)`
 
 @Entity()
+@Index({ name: ascOrderIndexName, expression: ascOrderIndexExpr })
+@Index({ name: descOrderIndexName, expression: descOrderIndexExpr })
 export default class LeaderboardEntry {
   @PrimaryKey()
   id!: number
 
-  @Index({ name: scoreIndexName, expression: scoreIndexExpr })
   @Property({ type: 'double' })
   score!: number
 
@@ -29,7 +37,6 @@ export default class LeaderboardEntry {
   })
   props: Collection<LeaderboardEntryProp> = new Collection<LeaderboardEntryProp>(this)
 
-  @Index()
   @Property({ default: false })
   hidden!: boolean
 

--- a/src/entities/leaderboard.ts
+++ b/src/entities/leaderboard.ts
@@ -7,7 +7,7 @@ import {
   PrimaryKey,
   Property,
 } from '@mikro-orm/decorators/es'
-import { Collection, EntityManager } from '@mikro-orm/mysql'
+import { Collection, EntityManager, OrderDefinition } from '@mikro-orm/mysql'
 import { isThisMonth, isThisWeek, isThisYear, isToday } from 'date-fns'
 import Game from './game.js'
 import LeaderboardEntry from './leaderboard-entry.js'
@@ -81,6 +81,58 @@ export default class Leaderboard {
 
   isDateInCurrentPeriod(date: Date) {
     return refreshCheckers[this.refreshInterval](date)
+  }
+
+  getEntryOrder(): OrderDefinition<LeaderboardEntry> {
+    return {
+      score: this.sortMode,
+      createdAt: 'asc',
+      id: 'asc',
+    }
+  }
+
+  getBaseEntryFilters(includeDevData: boolean): {
+    leaderboard: Leaderboard
+    hidden: boolean
+    deletedAt: Date | null
+    playerAlias?: { player: { devBuild: boolean } }
+  } {
+    return {
+      leaderboard: this,
+      hidden: false,
+      deletedAt: null,
+      ...(includeDevData ? {} : { playerAlias: { player: { devBuild: false } } }),
+    }
+  }
+
+  // position = number of entries sorting before this one, per getEntryOrder()
+  // two separate range counts so both can use the score indexes
+  async getEntryPosition({
+    em,
+    entry,
+    includeDevData,
+  }: {
+    em: EntityManager
+    entry: LeaderboardEntry
+    includeDevData: boolean
+  }) {
+    const asc = this.sortMode === LeaderboardSortMode.ASC
+
+    // rounded to second precision to match MySQL datetime storage
+    const createdAt = new Date(Math.round(entry.createdAt.getTime() / 1000) * 1000)
+
+    const betterScore = await em.repo(LeaderboardEntry).count({
+      ...this.getBaseEntryFilters(includeDevData),
+      score: asc ? { $lt: entry.score } : { $gt: entry.score },
+    })
+
+    const betterTie = await em.repo(LeaderboardEntry).count({
+      ...this.getBaseEntryFilters(includeDevData),
+      score: entry.score,
+      $or: [{ createdAt: { $lt: createdAt } }, { createdAt, id: { $lt: entry.id } }],
+    })
+
+    return betterScore + betterTie
   }
 
   async findEntryWithProps({

--- a/src/entities/player-group-rule.ts
+++ b/src/entities/player-group-rule.ts
@@ -109,6 +109,13 @@ export default class PlayerGroupRule {
     return raw((alias) => `cast(${alias}.${key} as ${this.castType})`)
   }
 
+  // ensure native DOUBLE columns aren't casted so they can use the right indexes
+  private getComparisonKey(key: string): string {
+    return this.castType === PlayerGroupRuleCastType.DOUBLE
+      ? raw((alias) => `${alias}.${key}`)
+      : this.getCastedKey(key)
+  }
+
   private getOperand(idx: number): string {
     return raw(`cast('${this.operands[idx]}' as ${this.castType})`)
   }
@@ -157,7 +164,7 @@ export default class PlayerGroupRule {
         stat: {
           internalName: this.getNamespacedValue('statValue'),
         },
-        [this.getCastedKey('value')]: fieldQuery,
+        [this.getComparisonKey('value')]: fieldQuery,
       })
   }
 
@@ -171,7 +178,8 @@ export default class PlayerGroupRule {
           internalName: this.getNamespacedValue('leaderboardEntryScore'),
         },
         hidden: false,
-        [this.getCastedKey('score')]: fieldQuery,
+        deletedAt: null,
+        [this.getComparisonKey('score')]: fieldQuery,
       })
   }
 

--- a/src/lib/leaderboards/getEntryPositions.ts
+++ b/src/lib/leaderboards/getEntryPositions.ts
@@ -1,0 +1,110 @@
+import { EntityManager, raw } from '@mikro-orm/mysql'
+import assert from 'node:assert'
+import LeaderboardEntry from '../../entities/leaderboard-entry.js'
+import Leaderboard, { LeaderboardSortMode } from '../../entities/leaderboard.js'
+
+type ScoreGroup = {
+  score: number
+  createdAt: number
+  count: number
+}
+
+type ScoreBlock = {
+  start: number
+  end: number
+}
+
+// positions for a batch of entries in one grouped query
+// entries sharing their exact score and createdAt with other entries
+// need one extra count for the id tie-break
+export async function getEntryPositions({
+  em,
+  leaderboard,
+  entries,
+  includeDevData,
+}: {
+  em: EntityManager
+  leaderboard: Leaderboard
+  entries: LeaderboardEntry[]
+  includeDevData: boolean
+}): Promise<number[]> {
+  if (entries.length === 0) {
+    return []
+  }
+
+  const filters = leaderboard.getBaseEntryFilters(includeDevData)
+
+  // entry counts per (score, createdAt) across the leaderboard
+  const rows = await em
+    .qb(LeaderboardEntry)
+    .select(['score', 'createdAt', raw('count(*)').as('count')])
+    .where(filters)
+    .groupBy(['score', 'createdAt'])
+    .execute<{ score: number; createdAt: Date; count: number }[]>('all')
+
+  // ascending by (score, createdAt); the id tie-break is resolved per entry below
+  const groups: ScoreGroup[] = rows
+    .map((row) => ({
+      score: Number(row.score),
+      createdAt: new Date(row.createdAt).getTime(),
+      count: Number(row.count),
+    }))
+    .sort((a, b) => a.score - b.score || a.createdAt - b.createdAt)
+
+  // cumulative count of entries up to (but excluding) each group
+  const totals = [0]
+  groups.forEach((group, idx) => totals.push(totals[idx] + group.count))
+  const total = totals[groups.length]
+
+  const scoreBlocks = new Map<number, ScoreBlock>()
+  const groupIndexes = new Map<string, number>()
+  groups.forEach((group, idx) => {
+    const block = scoreBlocks.get(group.score)
+    if (block) {
+      block.end = idx + 1
+    } else {
+      scoreBlocks.set(group.score, { start: idx, end: idx + 1 })
+    }
+
+    groupIndexes.set(`${group.score}:${group.createdAt}`, idx)
+  })
+
+  const asc = leaderboard.sortMode === LeaderboardSortMode.ASC
+
+  return Promise.all(
+    entries.map(async (entry) => {
+      const score = entry.score
+      const createdAt = entry.createdAt.getTime()
+      const block = scoreBlocks.get(score)
+      const groupIdx = groupIndexes.get(`${score}:${createdAt}`)
+
+      // in-memory entries aren't in the histogram yet - they must be persisted first
+      assert(block)
+      assert(groupIdx !== undefined)
+
+      // lower scores rank first on asc leaderboards, last on desc ones
+      const betterScore = asc ? totals[block.start] : total - totals[block.end]
+
+      // same-score groups with an earlier createdAt rank first on both sort modes
+      let earlier = block.start
+      while (groups[earlier].createdAt < createdAt) {
+        earlier++
+      }
+      const sameScoreEarlier = totals[earlier] - totals[block.start]
+
+      let position = betterScore + sameScoreEarlier
+
+      // entries sharing the exact score and createdAt need the id tie-break
+      if (groups[groupIdx].count > 1) {
+        position += await em.repo(LeaderboardEntry).count({
+          ...filters,
+          score,
+          createdAt: entry.createdAt,
+          id: { $lt: entry.id },
+        })
+      }
+
+      return position
+    }),
+  )
+}

--- a/src/migrations/.snapshot-gs_dev.json
+++ b/src/migrations/.snapshot-gs_dev.json
@@ -4358,21 +4358,22 @@
           "unique": true
         },
         {
-          "columnNames": ["score"],
+          "columnNames": [],
           "composite": false,
           "constraint": false,
-          "keyName": "idx_leaderboardentry_hidden_leaderboard_id_score",
+          "keyName": "idx_leaderboardentry_order_asc",
           "primary": false,
           "unique": false,
-          "expression": "alter table `leaderboard_entry` add index `idx_leaderboardentry_hidden_leaderboard_id_score`(`hidden`, `leaderboard_id`, `score`)"
+          "expression": "alter table `leaderboard_entry` add index `idx_leaderboardentry_order_asc`(`leaderboard_id`, `hidden`, `deleted_at`, `score`, `created_at`, `id`)"
         },
         {
-          "columnNames": ["hidden"],
+          "columnNames": [],
           "composite": false,
           "constraint": false,
-          "keyName": "leaderboard_entry_hidden_index",
+          "keyName": "idx_leaderboardentry_order_desc",
           "primary": false,
-          "unique": false
+          "unique": false,
+          "expression": "alter table `leaderboard_entry` add index `idx_leaderboardentry_order_desc`(`leaderboard_id`, `hidden`, `deleted_at`, `score` desc, `created_at`, `id`)"
         },
         {
           "columnNames": ["leaderboard_id"],

--- a/src/migrations/20260909210826AddLeaderboardEntryOrderIndexes.ts
+++ b/src/migrations/20260909210826AddLeaderboardEntryOrderIndexes.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class AddLeaderboardEntryOrderIndexes extends Migration {
+  override up(): void | Promise<void> {
+    this.addSql(
+      `alter table \`leaderboard_entry\` add index \`idx_leaderboardentry_order_desc\`(\`leaderboard_id\`, \`hidden\`, \`deleted_at\`, \`score\` desc, \`created_at\`, \`id\`);`,
+    )
+    this.addSql(
+      `alter table \`leaderboard_entry\` add index \`idx_leaderboardentry_order_asc\`(\`leaderboard_id\`, \`hidden\`, \`deleted_at\`, \`score\`, \`created_at\`, \`id\`);`,
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(`alter table \`leaderboard_entry\` drop index \`idx_leaderboardentry_order_desc\`;`)
+    this.addSql(`alter table \`leaderboard_entry\` drop index \`idx_leaderboardentry_order_asc\`;`)
+  }
+}

--- a/src/migrations/20260909211348DropRedundantLeaderboardEntryIndexes.ts
+++ b/src/migrations/20260909211348DropRedundantLeaderboardEntryIndexes.ts
@@ -1,0 +1,28 @@
+import { Migration } from '@mikro-orm/migrations'
+
+export class DropRedundantLeaderboardEntryIndexes extends Migration {
+  override up(): void | Promise<void> {
+    this.addSql(`alter table \`leaderboard_entry\` drop index \`leaderboard_entry_hidden_index\`;`)
+
+    // both order indexes lead with leaderboard_id, so the auto-created fk index is redundant
+    this.addSql(
+      `alter table \`leaderboard_entry\` drop index \`leaderboard_entry_leaderboard_id_index\`;`,
+    )
+
+    this.addSql(
+      `alter table \`leaderboard_entry\` drop index \`idx_leaderboardentry_hidden_leaderboard_id_score\`;`,
+    )
+  }
+
+  override down(): void | Promise<void> {
+    this.addSql(
+      `alter table \`leaderboard_entry\` add index \`leaderboard_entry_hidden_index\` (\`hidden\`);`,
+    )
+    this.addSql(
+      `alter table \`leaderboard_entry\` add index \`leaderboard_entry_leaderboard_id_index\` (\`leaderboard_id\`);`,
+    )
+    this.addSql(
+      `alter table \`leaderboard_entry\` add index \`idx_leaderboardentry_hidden_leaderboard_id_score\`(\`hidden\`, \`leaderboard_id\`, \`score\`);`,
+    )
+  }
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -84,6 +84,8 @@ import { RemoveIntegrationSoftDelete } from './20260905054226RemoveIntegrationSo
 import { LinkSteamworksEntitiesToIntegration } from './20260905070622LinkSteamworksEntitiesToIntegration.js'
 import { WidenSteamworksLeaderboardMappingPk } from './20260905094358WidenSteamworksLeaderboardMappingPk.js'
 import { CreateEventRetentionTable } from './20260905132019CreateEventRetentionTable.js'
+import { AddLeaderboardEntryOrderIndexes } from './20260909210826AddLeaderboardEntryOrderIndexes.js'
+import { DropRedundantLeaderboardEntryIndexes } from './20260909211348DropRedundantLeaderboardEntryIndexes.js'
 
 export default [
   InitialMigration,
@@ -172,4 +174,6 @@ export default [
   LinkSteamworksEntitiesToIntegration,
   WidenSteamworksLeaderboardMappingPk,
   CreateEventRetentionTable,
+  AddLeaderboardEntryOrderIndexes,
+  DropRedundantLeaderboardEntryIndexes,
 ]

--- a/src/routes/api/leaderboard/docs.ts
+++ b/src/routes/api/leaderboard/docs.ts
@@ -14,7 +14,7 @@ export const getDocs = {
             score: 593.21,
             leaderboardName: 'Highscore',
             leaderboardInternalName: 'highscore',
-            leaderboardSortMode: 'asc',
+            leaderboardSortMode: 'desc',
             playerAlias: {
               id: 1,
               service: 'steam',
@@ -42,7 +42,7 @@ export const getDocs = {
             score: 400.06,
             leaderboardName: 'Highscore',
             leaderboardInternalName: 'highscore',
-            leaderboardSortMode: 'asc',
+            leaderboardSortMode: 'desc',
             playerAlias: {
               id: 1,
               service: 'epic',
@@ -120,6 +120,75 @@ export const getDocs = {
   ],
 } satisfies RouteDocs
 
+export const topDocs = {
+  description: "Get a leaderboard's top entries alongside the current player's entries",
+  samples: [
+    {
+      title: 'Sample response',
+      sample: {
+        topEntries: [
+          {
+            id: 4,
+            position: 0,
+            score: 593.21,
+            leaderboardName: 'Highscore',
+            leaderboardInternalName: 'highscore',
+            leaderboardSortMode: 'desc',
+            playerAlias: {
+              id: 1,
+              service: 'steam',
+              identifier: '11133645',
+              displayName: '11133645',
+              player: {
+                id: '7a4e70ec-6ee6-418e-923d-b3a45051b7f9',
+                devBuild: false,
+              },
+            },
+            hidden: false,
+            createdAt: '2022-01-15T14:01:18.727Z',
+            updatedAt: '2022-01-15T14:01:18.727Z',
+          },
+          '/* ...9 more entries */',
+        ],
+        playerEntries: [
+          {
+            position: 41,
+            id: 126,
+            score: 100,
+            leaderboardName: 'Highscore',
+            leaderboardInternalName: 'highscore',
+            leaderboardSortMode: 'desc',
+            playerAlias: {
+              id: 41,
+              service: 'steam',
+              identifier: '11133645',
+              displayName: '11133645',
+              player: {
+                id: '7a4e70ec-6ee6-418e-923d-b3a45051b7f9',
+                devBuild: false,
+              },
+            },
+            hidden: false,
+            props: [],
+            createdAt: '2022-01-15T14:01:18.727Z',
+            updatedAt: '2022-01-15T14:01:18.727Z',
+            deletedAt: null,
+          },
+        ],
+      },
+    },
+    {
+      title: 'Sample request with a limit',
+      sample: {
+        url: '/v1/leaderboards/highscore/entries/top?limit=25',
+        query: {
+          limit: '25',
+        },
+      },
+    },
+  ],
+} satisfies RouteDocs
+
 export const postDocs = {
   description:
     "Create or update a leaderboard's entry\nIf an entry exists for the player and the leaderboard mode is set to unique, that entry will be updated with the new score (and the updated key will return true)",
@@ -133,7 +202,7 @@ export const postDocs = {
           score: 593.21,
           leaderboardName: 'Highscore',
           leaderboardInternalName: 'highscore',
-          leaderboardSortMode: 'asc',
+          leaderboardSortMode: 'desc',
           playerAlias: {
             id: 1,
             service: 'steam',

--- a/src/routes/api/leaderboard/index.ts
+++ b/src/routes/api/leaderboard/index.ts
@@ -2,12 +2,14 @@ import type Router from 'koa-tree-router'
 import { apiRouter } from '../../../lib/routing/router.js'
 import { getRoute } from './get.js'
 import { postRoute } from './post.js'
+import { topRoute } from './top.js'
 
 export function leaderboardAPIRouter(router: Router) {
   apiRouter(
     '/v1/leaderboards',
     ({ route }) => {
       route(getRoute)
+      route(topRoute)
       route(postRoute)
     },
     {

--- a/src/routes/api/leaderboard/post.ts
+++ b/src/routes/api/leaderboard/post.ts
@@ -193,31 +193,11 @@ export const postRoute = apiRoute({
         return integration.handleLeaderboardEntryCreated(em, entry)
       })
 
-      const query = em
-        .qb(LeaderboardEntry)
-        .where({
-          leaderboard,
-          hidden: false,
-          deletedAt: null,
-          score:
-            leaderboard.sortMode === LeaderboardSortMode.ASC
-              ? { $lte: entry.score }
-              : { $gte: entry.score },
-        })
-        .orderBy({ createdAt: 'asc' })
-
-      if (!ctx.state.includeDevData) {
-        query.andWhere({
-          playerAlias: {
-            player: {
-              devBuild: false,
-            },
-          },
-        })
-      }
-
-      const { count } = await query.count().execute('get')
-      const position = Math.max(count - 1, 0)
+      const position = await leaderboard.getEntryPosition({
+        em,
+        entry,
+        includeDevData: ctx.state.includeDevData,
+      })
       await entry.playerAlias.player.checkGroupMemberships(em)
 
       return {

--- a/src/routes/api/leaderboard/top.ts
+++ b/src/routes/api/leaderboard/top.ts
@@ -1,0 +1,91 @@
+import { APIKeyScope } from '../../../entities/api-key.js'
+import LeaderboardEntry from '../../../entities/leaderboard-entry.js'
+import { getEntryPositions } from '../../../lib/leaderboards/getEntryPositions.js'
+import { apiRoute, withMiddleware } from '../../../lib/routing/router.js'
+import { playerAliasHeaderSchema } from '../../../lib/validation/playerAliasHeaderSchema.js'
+import { loadAlias } from '../../../middleware/player-alias-middleware.js'
+import { requireScopes } from '../../../middleware/policy-middleware.js'
+import { loadLeaderboard } from './common.js'
+import { topDocs } from './docs.js'
+
+const MAX_TOP_ENTRIES = 200
+
+export const topRoute = apiRoute({
+  method: 'get',
+  path: '/:internalName/entries/top',
+  docs: topDocs,
+  schema: (z) => ({
+    headers: z.looseObject({
+      'x-talo-alias': playerAliasHeaderSchema,
+    }),
+    route: z.object({
+      internalName: z.string().meta({ description: 'The internal name of the leaderboard' }),
+    }),
+    query: z.object({
+      limit: z.coerce
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_TOP_ENTRIES)
+        .meta({
+          description: `The maximum number of entries to return in each list (max ${MAX_TOP_ENTRIES})`,
+        }),
+    }),
+  }),
+  middleware: withMiddleware(
+    requireScopes([APIKeyScope.READ_LEADERBOARDS]),
+    loadLeaderboard,
+    loadAlias,
+  ),
+  handler: async (ctx) => {
+    const { limit } = ctx.state.validated.query
+    const { leaderboard, includeDevData } = ctx.state
+
+    const em = ctx.em
+
+    const where = leaderboard.getBaseEntryFilters(includeDevData)
+
+    const orderBy = leaderboard.getEntryOrder()
+
+    const topEntries = await em.repo(LeaderboardEntry).find(where, {
+      orderBy,
+      limit,
+    })
+
+    const playerEntries = await em.repo(LeaderboardEntry).find(
+      {
+        ...where,
+        playerAlias: {
+          id: ctx.state.alias.id,
+          ...(includeDevData ? {} : { player: { devBuild: false } }),
+        },
+      },
+      { orderBy, limit },
+    )
+
+    const positions = await getEntryPositions({
+      em,
+      leaderboard,
+      entries: playerEntries,
+      includeDevData,
+    })
+
+    const mappedPlayerEntries = playerEntries.map((entry, idx) => ({
+      position: positions[idx],
+      ...entry.toJSON(),
+    }))
+
+    const mappedTopEntries = topEntries.map((entry, idx) => ({
+      position: idx,
+      ...entry.toJSON(),
+    }))
+
+    return {
+      status: 200,
+      body: {
+        topEntries: mappedTopEntries,
+        playerEntries: mappedPlayerEntries,
+      },
+    }
+  },
+})

--- a/src/routes/protected/leaderboard/entries.ts
+++ b/src/routes/protected/leaderboard/entries.ts
@@ -62,10 +62,7 @@ async function getGlobalEntryIds({
           },
         ],
       })
-      .orderBy({
-        score: leaderboard.sortMode,
-        createdAt: 'asc',
-      })
+      .orderBy(leaderboard.getEntryOrder())
 
     if (!includeDevData) {
       globalQuery.andWhere({
@@ -216,10 +213,7 @@ export async function listEntriesHandler({
       }
 
       const [entries, count] = await em.repo(LeaderboardEntry).findAndCount(where, {
-        orderBy: {
-          score: leaderboard.sortMode,
-          createdAt: 'asc',
-        },
+        orderBy: leaderboard.getEntryOrder(),
         limit: itemsPerPage + 1,
         offset: page * itemsPerPage,
         populate: ['playerAlias'],

--- a/tests/entities/player-group-rule/equals-rule.test.ts
+++ b/tests/entities/player-group-rule/equals-rule.test.ts
@@ -169,6 +169,41 @@ describe('EQUALS rule', () => {
     expect(res.body.count).toEqual(1)
   })
 
+  it('should correctly evaluate an EQUALS rule with stat values casted to CHAR', async () => {
+    const [organisation, game] = await createOrganisationAndGame()
+    const [token] = await createUserAndToken({}, organisation)
+
+    const player1 = await new PlayerFactory([game]).one()
+    const player2 = await new PlayerFactory([game]).one()
+
+    const stat = await new GameStatFactory([game])
+      .state(() => ({ minValue: 1, maxValue: 80 }))
+      .one()
+    const playerStat = await new PlayerGameStatFactory()
+      .construct(player1, stat)
+      .state(() => ({ value: 60 }))
+      .one()
+    await em.persist([player1, player2, playerStat]).flush()
+
+    const rules: Partial<PlayerGroupRule>[] = [
+      {
+        name: PlayerGroupRuleName.EQUALS,
+        field: `statValue.${stat.internalName}`,
+        operands: ['60'],
+        negate: false,
+        castType: PlayerGroupRuleCastType.CHAR,
+      },
+    ]
+
+    const res = await request(app)
+      .get(`/games/${game.id}/player-groups/preview-count`)
+      .query({ ruleMode: '$and', rules: encodeURI(JSON.stringify(rules)) })
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.count).toEqual(1)
+  })
+
   it('should correctly evaluate a negated EQUALS rule with stat values', async () => {
     const [organisation, game] = await createOrganisationAndGame()
     const [token] = await createUserAndToken({}, organisation)

--- a/tests/routes/api/leaderboard/top.test.ts
+++ b/tests/routes/api/leaderboard/top.test.ts
@@ -1,0 +1,563 @@
+import request from 'supertest'
+import { APIKeyScope } from '../../../../src/entities/api-key.js'
+import { LeaderboardSortMode } from '../../../../src/entities/leaderboard.js'
+import LeaderboardEntryFactory from '../../../fixtures/LeaderboardEntryFactory.js'
+import LeaderboardFactory from '../../../fixtures/LeaderboardFactory.js'
+import PlayerFactory from '../../../fixtures/PlayerFactory.js'
+import createAPIKeyAndToken from '../../../utils/createAPIKeyAndToken.js'
+
+describe('Leaderboard API - top', () => {
+  it('should require a limit', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const player = await new PlayerFactory([apiKey.game]).one()
+
+    await em.persist([leaderboard, player]).flush()
+
+    await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should not return more than 200 entries', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const player = await new PlayerFactory([apiKey.game]).one()
+
+    await em.persist([leaderboard, player]).flush()
+
+    await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 201 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(400)
+  })
+
+  it('should return the top entries up to the limit', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(5)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(5)
+
+    await em.persist([player, ...players, ...entries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 3 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(3)
+    expect(res.body.topEntries.map((e: { position: number }) => e.position)).toEqual([0, 1, 2])
+    expect(res.body.playerEntries).toHaveLength(0)
+  })
+
+  it('should return the top entries in ascending order for asc leaderboards', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.ASC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(3)
+
+    await em.persist([player, ...players, ...entries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 3 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(3)
+    expect(Number(res.body.topEntries[0].score)).toBeLessThanOrEqual(
+      Number(res.body.topEntries[2].score),
+    )
+  })
+
+  it('should return the top entries in descending order for desc leaderboards', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(3)
+
+    await em.persist([player, ...players, ...entries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 3 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(3)
+    expect(Number(res.body.topEntries[0].score)).toBeGreaterThanOrEqual(
+      Number(res.body.topEntries[2].score),
+    )
+  })
+
+  it('should return the player entry with its global position when outside the top entries', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const playerEntry = await new LeaderboardEntryFactory(leaderboard, [player])
+      .state(() => ({
+        playerAlias: player.aliases[0],
+        score: 100,
+      }))
+      .one()
+
+    const otherPlayers = await new PlayerFactory([apiKey.game]).many(3)
+    const otherEntries = await new LeaderboardEntryFactory(leaderboard, otherPlayers)
+      .state(() => ({ score: 200 }))
+      .many(3)
+
+    await em.persist([player, playerEntry, ...otherPlayers, ...otherEntries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 2 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(2)
+    expect(res.body.playerEntries[0].position).toBe(3)
+    expect(res.body.playerEntries[0].id).toBe(playerEntry.id)
+  })
+
+  it('should return the player entry global position on asc leaderboards', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.ASC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const playerEntry = await new LeaderboardEntryFactory(leaderboard, [player])
+      .state(() => ({
+        playerAlias: player.aliases[0],
+        score: 300,
+      }))
+      .one()
+
+    const otherPlayers = await new PlayerFactory([apiKey.game]).many(3)
+    const otherEntries = await new LeaderboardEntryFactory(leaderboard, otherPlayers)
+      .state(() => ({ score: 100 }))
+      .many(3)
+
+    await em.persist([player, playerEntry, ...otherPlayers, ...otherEntries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 2 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(2)
+    expect(res.body.playerEntries[0].position).toBe(3)
+    expect(res.body.playerEntries[0].id).toBe(playerEntry.id)
+  })
+
+  it('should return the player entry position 0 when the player is first', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const playerEntry = await new LeaderboardEntryFactory(leaderboard, [player])
+      .state(() => ({
+        playerAlias: player.aliases[0],
+        score: 300,
+      }))
+      .one()
+
+    const otherPlayers = await new PlayerFactory([apiKey.game]).many(2)
+    const otherEntries = await new LeaderboardEntryFactory(leaderboard, otherPlayers)
+      .state(() => ({ score: 100 }))
+      .many(2)
+
+    await em.persist([player, playerEntry, ...otherPlayers, ...otherEntries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 3 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.playerEntries[0].position).toBe(0)
+    expect(res.body.topEntries[0].id).toBe(playerEntry.id)
+  })
+
+  it('should give tied entries inside the top entries a consistent position', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(3)
+    entries.forEach((entry, idx) => {
+      entry.playerAlias = players[idx].aliases[0]
+      entry.score = 100
+      entry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, idx))
+    })
+
+    await em.persist([...players, ...entries]).flush()
+
+    const player = players[1]
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 2 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries.map((e: { id: number }) => e.id)).toEqual([
+      entries[0].id,
+      entries[1].id,
+    ])
+    expect(res.body.playerEntries[0].id).toBe(entries[1].id)
+    expect(res.body.playerEntries[0].position).toBe(1)
+    expect(res.body.playerEntries[0].position).toBe(res.body.topEntries[1].position)
+  })
+
+  it('should rank tied entries by createdAt when outside the top entries', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const betterPlayer = await new PlayerFactory([apiKey.game]).one()
+    const betterEntry = await new LeaderboardEntryFactory(leaderboard, [betterPlayer])
+      .state(() => ({ score: 200 }))
+      .one()
+
+    const players = await new PlayerFactory([apiKey.game]).many(3)
+    const tiedEntries = await new LeaderboardEntryFactory(leaderboard, players).many(3)
+    tiedEntries.forEach((entry, idx) => {
+      entry.playerAlias = players[idx].aliases[0]
+      entry.score = 100
+      entry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, idx))
+    })
+
+    await em.persist([betterPlayer, betterEntry, ...players, ...tiedEntries]).flush()
+
+    const player = players[2]
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries[0].id).toBe(betterEntry.id)
+    expect(res.body.playerEntries[0].id).toBe(tiedEntries[2].id)
+    expect(res.body.playerEntries[0].position).toBe(3)
+  })
+
+  it('should rank tied entries with identical createdAt by id', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const players = await new PlayerFactory([apiKey.game]).many(2)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(2)
+    entries.forEach((entry, idx) => {
+      entry.playerAlias = players[idx].aliases[0]
+      entry.score = 100
+      entry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, 0))
+    })
+
+    await em.persist([...players, ...entries]).flush()
+
+    // players[1]'s entry was persisted second so it has the higher id and loses the tie
+    const player = players[1]
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries[0].id).toBe(entries[0].id)
+    expect(res.body.playerEntries[0].id).toBe(entries[1].id)
+    expect(res.body.playerEntries[0].position).toBe(1)
+  })
+
+  it("should rank the player's own tied entries by id", async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .notUnique()
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const entries = await new LeaderboardEntryFactory(leaderboard, [player]).many(2)
+    entries.forEach((entry) => {
+      entry.playerAlias = player.aliases[0]
+      entry.score = 100
+      entry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, 0))
+    })
+
+    await em.persist([player, ...entries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 5 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    // the entry persisted first has the lower id and wins the tie
+    expect(res.body.playerEntries.map((e: { position: number }) => e.position)).toEqual([0, 1])
+  })
+
+  it('should return no player entries if the player has no entry', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const players = await new PlayerFactory([apiKey.game]).many(2)
+    const entries = await new LeaderboardEntryFactory(leaderboard, players).many(2)
+
+    await em.persist([player, ...players, ...entries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.playerEntries).toHaveLength(0)
+  })
+
+  it('should not get top entries for an alias that does not belong to the game', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+    const player = await new PlayerFactory([apiKey.game]).one()
+
+    await em.persist([leaderboard, player]).flush()
+
+    await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', '9999')
+      .auth(token, { type: 'bearer' })
+      .expect(404)
+  })
+
+  it('should not return hidden entries', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const playerEntry = await new LeaderboardEntryFactory(leaderboard, [player])
+      .state(() => ({ playerAlias: player.aliases[0] }))
+      .hidden()
+      .one()
+
+    const otherPlayers = await new PlayerFactory([apiKey.game]).many(2)
+    const hiddenEntries = await new LeaderboardEntryFactory(leaderboard, otherPlayers)
+      .hidden()
+      .many(2)
+
+    await em.persist([player, playerEntry, ...otherPlayers, ...hiddenEntries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(0)
+    expect(res.body.playerEntries).toHaveLength(0)
+  })
+
+  it('should not return dev build entries', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const devPlayer = await new PlayerFactory([apiKey.game]).devBuild().one()
+    const devEntries = await new LeaderboardEntryFactory(leaderboard, [devPlayer]).many(2)
+
+    const normalPlayer = await new PlayerFactory([apiKey.game]).one()
+    const normalEntry = await new LeaderboardEntryFactory(leaderboard, [normalPlayer]).one()
+
+    await em.persist([player, devPlayer, ...devEntries, normalPlayer, normalEntry]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 3 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(1)
+    expect(res.body.topEntries[0].id).toBe(normalEntry.id)
+    expect(res.body.playerEntries).toHaveLength(0)
+  })
+
+  it('should return dev build entries when dev data is included', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game]).one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const devPlayer = await new PlayerFactory([apiKey.game]).devBuild().one()
+    const devEntries = await new LeaderboardEntryFactory(leaderboard, [devPlayer]).many(2)
+
+    await em.persist([player, devPlayer, ...devEntries]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 2 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .set('x-talo-include-dev-data', '1')
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries).toHaveLength(2)
+    expect(
+      res.body.topEntries.map((e: { id: number }) => e.id).sort((a: number, b: number) => a - b),
+    ).toEqual(devEntries.map((e) => e.id).sort((a: number, b: number) => a - b))
+  })
+
+  it('should round sub-second createdAt values to seconds when ranking ties', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const players = await new PlayerFactory([apiKey.game]).many(2)
+    const [roundedDownEntry, roundedUpEntry] = await new LeaderboardEntryFactory(
+      leaderboard,
+      players,
+    ).many(2)
+    roundedDownEntry.playerAlias = players[0].aliases[0]
+    roundedDownEntry.score = 100
+    roundedDownEntry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, 0, 200))
+    roundedUpEntry.playerAlias = players[1].aliases[0]
+    roundedUpEntry.score = 100
+    roundedUpEntry.createdAt = new Date(Date.UTC(2022, 0, 1, 0, 0, 0, 700))
+
+    await em.persist([...players, roundedDownEntry, roundedUpEntry]).flush()
+
+    // MySQL rounds .200 down to :00 and .700 up to :01, so the .700 entry ranks after
+    const player = players[1]
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 1 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.topEntries[0].id).toBe(roundedDownEntry.id)
+    expect(res.body.playerEntries[0].id).toBe(roundedUpEntry.id)
+    expect(res.body.playerEntries[0].position).toBe(1)
+  })
+
+  it("should return all of a player's entries on a non-unique leaderboard", async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .notUnique()
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const entries = await new LeaderboardEntryFactory(leaderboard, [player]).many(8)
+    entries.forEach((entry, idx) => {
+      entry.playerAlias = player.aliases[0]
+      entry.score = idx + 1
+    })
+
+    const otherPlayer = await new PlayerFactory([apiKey.game]).one()
+    const otherEntry = await new LeaderboardEntryFactory(leaderboard, [otherPlayer])
+      .state(() => ({ playerAlias: otherPlayer.aliases[0], score: 1000 }))
+      .one()
+
+    await em.persist([player, ...entries, otherPlayer, otherEntry]).flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 5 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    expect(res.body.playerEntries).toHaveLength(5)
+    // best 5 of the 8 in rank order, positions 1-5 behind the opponent's score-1000 entry
+    expect(res.body.playerEntries.map((e: { score: number }) => Number(e.score))).toEqual([
+      8, 7, 6, 5, 4,
+    ])
+    expect(res.body.playerEntries.map((e: { position: number }) => e.position)).toEqual([
+      1, 2, 3, 4, 5,
+    ])
+  })
+
+  it('should rank player entries tied with other players on score and createdAt', async () => {
+    const [apiKey, token] = await createAPIKeyAndToken([APIKeyScope.READ_LEADERBOARDS])
+    const leaderboard = await new LeaderboardFactory([apiKey.game])
+      .notUnique()
+      .state(() => ({ sortMode: LeaderboardSortMode.DESC }))
+      .one()
+
+    const player = await new PlayerFactory([apiKey.game]).one()
+    const playerEntry = await new LeaderboardEntryFactory(leaderboard, [player])
+      .state(() => ({
+        playerAlias: player.aliases[0],
+        score: 100,
+        createdAt: new Date(Date.UTC(2022, 0, 1, 0, 0, 0)),
+      }))
+      .one()
+
+    const otherPlayer = await new PlayerFactory([apiKey.game]).one()
+    const otherEntry = await new LeaderboardEntryFactory(leaderboard, [otherPlayer])
+      .state(() => ({
+        playerAlias: otherPlayer.aliases[0],
+        score: 100,
+        createdAt: new Date(Date.UTC(2022, 0, 1, 0, 0, 0)),
+      }))
+      .one()
+
+    const betterPlayer = await new PlayerFactory([apiKey.game]).one()
+    const betterEntry = await new LeaderboardEntryFactory(leaderboard, [betterPlayer])
+      .state(() => ({ playerAlias: betterPlayer.aliases[0], score: 200 }))
+      .one()
+
+    await em
+      .persist([player, playerEntry, otherPlayer, otherEntry, betterPlayer, betterEntry])
+      .flush()
+
+    const res = await request(app)
+      .get(`/v1/leaderboards/${leaderboard.internalName}/entries/top`)
+      .query({ limit: 5 })
+      .set('x-talo-alias', String(player.aliases[0].id))
+      .auth(token, { type: 'bearer' })
+      .expect(200)
+
+    // the player entry was persisted first so it has the lower id and wins the tie
+    expect(res.body.playerEntries).toHaveLength(1)
+    expect(res.body.playerEntries[0].position).toBe(1)
+  })
+})


### PR DESCRIPTION
**Top entries endpoint**
- New `GET /v1/leaderboards/:internalName/entries/top` endpoint returns top N entries plus the requesting player's entries with their global positions
- Supports both ASC and DESC sort modes with consistent tie-breaking by score, then createdAt, then id
- Capped at 200 entries per list via `limit` query parameter
- Requires `READ_LEADERBOARDS` scope and a valid player alias header

**Entry position calculation**
- Extracted `getEntryPosition` into the `Leaderboard` entity with two-range count approach: one count for entries with better scores, another for tied entries ranking earlier by createdAt/id
- Added `getEntryPositions` batch helper that uses a grouped histogram query to efficiently compute positions for multiple player entries at once
- Positions for entries inside the top list use index positions directly

**Database indexes**
- Added two covering indexes (`idx_leaderboardentry_order_asc`, `idx_leaderboardentry_order_desc`) tailored to the sort patterns used by leaderboard queries
- Dropped three redundant indexes: the old `idx_leaderboardentry_hidden_leaderboard_id_score` composite index, the single-column `hidden` index, and the auto-created `leaderboard_id` foreign key index (covered by the new order indexes)

**Index usage fix**
- Fixed `PlayerGroupRule` to skip casting DOUBLE columns so they can use the new score indexes instead of forcing a full scan